### PR TITLE
Improve code coverage in sonar with lombok

### DIFF
--- a/src/main/resources/structure/root/lombok.config.mustache
+++ b/src/main/resources/structure/root/lombok.config.mustache
@@ -1,1 +1,2 @@
+config.stopBubbling = true
 lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
I've added a new property in the lombok.config to fix troubles with the code coverage when you are using lombok annotations