### PR TITLE
Implementation for issue #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
 
     ```shell
-   gradle generateEntryPoint --type=[entryPointType] --server=[serverOption]
-   gradle gep --type [entryPointType] --server=[serverOption]
+   gradle generateEntryPoint --type=restmvc --server=[serverOption]
+   gradle gep --type=restmvc --server=[serverOption]
    ```
 
    | Reference for **serverOption** | Name                      |

--- a/README.md
+++ b/README.md
@@ -231,11 +231,24 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    gradle gep --type [entryPointType]
    ```
 
-   | Reference for **entryPointType** | Name                                   | Additional Options |
-   | -------------------------------- | -------------------------------------- | ------------------ |
-   | generic                          | Empty Entry Point                      | --name [name]      |
-   | restmvc                          | API REST (Spring Boot Starter Web)     |                    |
-   | webflux                          | API REST (Spring Boot Starter WebFlux) |                    |
+   | Reference for **entryPointType** | Name                                   | Additional Options         |
+   | -------------------------------- | -------------------------------------- | -------------------------- |
+   | generic                          | Empty Entry Point                      | --name [name]              |
+   | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption]    |
+   | webflux                          | API REST (Spring Boot Starter WebFlux) |                            |
+
+   Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
+
+    ```shell
+   gradle generateEntryPoint --type=[entryPointType] --server=[serverOption]
+   gradle gep --type [entryPointType] --server=[serverOption]
+   ```
+
+   | Reference for **serverOption** | Name                      |
+      | ------------------------------ | ------------------------- |
+   | undertow                       | Undertow server (default) |
+   | tomcat                         | Tomcat server             |
+   | jetty                          | Jetty server              |
 
    _**This task will generate something like that:**_
 

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -170,8 +170,9 @@ public class PluginCleanFunctionalTest {
         canRunTaskGenerateStructureWithOutParameters();
         String task = "generateEntryPoint";
         String valueEntryPoint = "restmvc";
+        String server = "jetty";
 
-        runner.withArguments(task, "--type=" + valueEntryPoint);
+        runner.withArguments(task, "--type=" + valueEntryPoint, "--server=" + server);
         runner.withProjectDir(projectDir);
         BuildResult result = runner.build();
         assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -3,6 +3,7 @@
  */
 package co.com.bancolombia;
 
+import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -13,6 +14,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static org.junit.Assert.*;
@@ -170,6 +172,42 @@ public class PluginCleanFunctionalTest {
         canRunTaskGenerateStructureWithOutParameters();
         String task = "generateEntryPoint";
         String valueEntryPoint = "restmvc";
+
+        runner.withArguments(task, "--type=" + valueEntryPoint);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canRunTaskGenerateRestMvcEntryPointCaseWithUndertowServer() throws IOException {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueEntryPoint = "restmvc";
+        String server = "undertow";
+
+        runner.withArguments(task, "--type=" + valueEntryPoint, "--server=" + server);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+
+        assertTrue(FileUtils.readFileToString(new File("build/functionalTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("spring-boot-starter-undertow"));
+        assertTrue(FileUtils.readFileToString(new File("build/functionalTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canRunTaskGenerateRestMvcEntryPointCaseWithJettyServer() throws IOException {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueEntryPoint = "restmvc";
         String server = "jetty";
 
         runner.withArguments(task, "--type=" + valueEntryPoint, "--server=" + server);
@@ -177,6 +215,30 @@ public class PluginCleanFunctionalTest {
         BuildResult result = runner.build();
         assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
         assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+
+        assertTrue(FileUtils.readFileToString(new File("build/functionalTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("spring-boot-starter-jetty"));
+        assertTrue(FileUtils.readFileToString(new File("build/functionalTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canRunTaskGenerateEntryPointCaseWithTomcatServer() throws IOException {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueEntryPoint = "restmvc";
+        String server = "tomcat";
+
+        runner.withArguments(task, "--type=" + valueEntryPoint, "--server=" + server);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+
+        assertFalse(FileUtils.readFileToString(new File("build/functionalTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
 
         assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
     }

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
     public static final String PLUGIN_VERSION = "1.7.0";
+    public static final String UNDERTOW_VERSION = "2.3.8.RELEASE";
+    public static final String JETTY_VERSION = "2.3.8.RELEASE";
 
     public enum BooleanOption {
         TRUE, FALSE

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
     public static final String PLUGIN_VERSION = "1.7.0";
     public static final String UNDERTOW_VERSION = "2.3.8.RELEASE";
     public static final String JETTY_VERSION = "2.3.8.RELEASE";
+    public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
 
     public enum BooleanOption {
         TRUE, FALSE

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -108,6 +108,12 @@ public class ModuleBuilder {
         updateFile(buildFilePath, current -> Utils.addDependency(current, dependency));
     }
 
+    public void appendConfigurationToModule(String module, String configuration) throws IOException {
+        logger.lifecycle("adding configuration {} to module {}", configuration, module);
+        String buildFilePath = project.getChildProjects().get(module).getBuildFile().getPath();
+        updateFile(buildFilePath, current -> Utils.addConfiguration(current, configuration));
+    }
+
     public void removeDependencyFromModule(String module, String dependency) throws IOException {
         logger.lifecycle("removing dependency {} from module {}", dependency, module);
         String buildFilePath = project.getChildProjects().get(module).getBuildFile().getPath();
@@ -169,6 +175,8 @@ public class ModuleBuilder {
     public String getStringParam(String key) {
         return (String) params.get(key);
     }
+
+    public Object getParam(String key) { return params.get(key); }
 
     public Boolean getBooleanParam(String key) {
         return (Boolean) params.get(key);

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
@@ -7,11 +7,13 @@ import co.com.bancolombia.factory.ModuleFactory;
 import java.io.IOException;
 
 public class EntryPointRestMvc implements ModuleFactory {
+
     @Override
     public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
         builder.loadPackage();
         builder.setupFromTemplate("entry-point/rest-mvc");
         builder.appendToSettings("api-rest", "infrastructure/entry-points");
         builder.appendDependencyToModule("app-service", "implementation project(':api-rest')");
+        new EntryPointRestMvcServer().buildModule(builder);
     }
 }

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
@@ -1,0 +1,42 @@
+package co.com.bancolombia.factory.entrypoints;
+
+import co.com.bancolombia.Constants;
+import co.com.bancolombia.exceptions.InvalidTaskOptionException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+
+import java.io.IOException;
+
+public class EntryPointRestMvcServer implements ModuleFactory {
+
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, InvalidTaskOptionException {
+        Server server = (Server) builder.getParam("task-param-server");
+
+        switch (server){
+            case UNDERTOW:
+                builder.appendDependencyToModule("app-service",
+                        "compile group: 'org.springframework.boot', name: 'spring-boot-starter-undertow', " +
+                                "version: '" + Constants.UNDERTOW_VERSION + "'");
+                builder.appendConfigurationToModule("app-service",
+                        "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+                return;
+            case JETTY:
+                builder.appendDependencyToModule("app-service",
+                        "compile group: 'org.springframework.boot', name: 'spring-boot-starter-jetty', " +
+                                "version: '" + Constants.JETTY_VERSION + "'");
+                builder.appendConfigurationToModule("app-service",
+                        "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+                return;
+            case TOMCAT:
+                return;
+            default:
+                throw new InvalidTaskOptionException("Server option invalid");
+        }
+    }
+
+    public enum Server {
+        UNDERTOW, TOMCAT, JETTY
+    }
+
+}

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
@@ -19,14 +19,14 @@ public class EntryPointRestMvcServer implements ModuleFactory {
                         "compile group: 'org.springframework.boot', name: 'spring-boot-starter-undertow', " +
                                 "version: '" + Constants.UNDERTOW_VERSION + "'");
                 builder.appendConfigurationToModule("app-service",
-                        "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+                        Constants.TOMCAT_EXCLUSION);
                 return;
             case JETTY:
                 builder.appendDependencyToModule("app-service",
                         "compile group: 'org.springframework.boot', name: 'spring-boot-starter-jetty', " +
                                 "version: '" + Constants.JETTY_VERSION + "'");
                 builder.appendConfigurationToModule("app-service",
-                        "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+                        Constants.TOMCAT_EXCLUSION);
                 return;
             case TOMCAT:
                 return;

--- a/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
@@ -34,7 +34,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     public void setServer(Server server) { this.server = server; }
 
     @OptionValues("server")
-    public List<Server> getServerOptions() { return new ArrayList<>(Arrays.asList(Server.values())); }
+    public List<Server> getServerOptions() { return Arrays.asList(Server.values()); }
 
     @OptionValues("type")
     public List<EntryPointType> getTypes() {

--- a/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
@@ -3,6 +3,7 @@ package co.com.bancolombia.task;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.entrypoints.ModuleFactoryEntryPoint;
+import co.com.bancolombia.factory.entrypoints.EntryPointRestMvcServer.Server;
 import co.com.bancolombia.factory.entrypoints.ModuleFactoryEntryPoint.EntryPointType;
 import co.com.bancolombia.utils.Utils;
 import org.gradle.api.tasks.TaskAction;
@@ -17,6 +18,7 @@ import java.util.List;
 public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     private EntryPointType type;
     private String name;
+    private Server server = Server.UNDERTOW;
 
     @Option(option = "type", description = "Set type of entry point to be generated")
     public void setType(EntryPointType type) {
@@ -27,6 +29,12 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     public void setName(String name) {
         this.name = name;
     }
+
+    @Option(option = "server", description = "Set server on which the application will run when RESTMVC type")
+    public void setServer(Server server) { this.server = server; }
+
+    @OptionValues("server")
+    public List<Server> getServerOptions() { return new ArrayList<>(Arrays.asList(Server.values())); }
 
     @OptionValues("type")
     public List<EntryPointType> getTypes() {
@@ -44,6 +52,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
         logger.lifecycle("Clean Architecture plugin version: {}", Utils.getVersionPlugin());
         logger.lifecycle("Entry Point type: {}", type);
         builder.addParam("task-param-name", name);
+        builder.addParam("task-param-server", server);
         moduleFactory.buildModule(builder);
         builder.persist();
     }

--- a/src/main/java/co/com/bancolombia/utils/Utils.java
+++ b/src/main/java/co/com/bancolombia/utils/Utils.java
@@ -78,6 +78,18 @@ public class Utils {
         return build.substring(0, realStart + 1) + "\n\t" + dependency + build.substring(realStart + 1);
     }
 
+    public static String addConfiguration(String build, String configuration) {
+        if(!build.contains("configurations")) {
+            build += "\n\nconfigurations{\n}";
+        }
+        if(build.contains(configuration)) {
+            return build;
+        }
+        int start = build.indexOf("configurations");
+        int realStart = build.indexOf('{', start);
+        return build.substring(0, realStart + 1) + "\n\t" + configuration + build.substring(realStart + 1);
+    }
+
     public static String toDashName(String name) {
         String regex = "(?=[A-Z][a-z])";
         String subst = "-";

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -1,15 +1,19 @@
 package co.com.bancolombia.task;
 
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.entrypoints.EntryPointRestMvcServer;
 import co.com.bancolombia.factory.entrypoints.ModuleFactoryEntryPoint;
 import org.gradle.api.Project;
+import org.apache.commons.io.FileUtils;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -75,7 +79,7 @@ public class GenerateEntryPointTaskTest {
     }
 
     @Test
-    public void generateEntryPointApiRest() throws IOException, CleanException {
+    public void generateEntryPointApiRestWithDefaultServer() throws IOException, CleanException {
         // Arrange
         task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);
         // Act
@@ -84,6 +88,58 @@ public class GenerateEntryPointTaskTest {
         assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
         assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
         assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api").exists());
+    }
+
+    @Test
+    public void generateEntryPointApiRestWithUndertowServer() throws IOException, CleanException {
+        // Arrange
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);
+        task.setServer(EntryPointRestMvcServer.Server.UNDERTOW);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api").exists());
+
+        assertTrue(FileUtils.readFileToString(new File("build/unitTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("spring-boot-starter-undertow"));
+        assertTrue(FileUtils.readFileToString(new File("build/unitTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+    }
+
+    @Test
+    public void generateEntryPointApiRestWithJettyServer() throws IOException, CleanException {
+        // Arrange
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);
+        task.setServer(EntryPointRestMvcServer.Server.JETTY);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api").exists());
+
+        assertTrue(FileUtils.readFileToString(new File("build/unitTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("spring-boot-starter-jetty"));
+        assertTrue(FileUtils.readFileToString(new File("build/unitTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+    }
+
+    @Test
+    public void generateEntryPointApiRestWithTomcatServer() throws IOException, CleanException {
+        // Arrange
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);
+        task.setServer(EntryPointRestMvcServer.Server.TOMCAT);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api").exists());
+
+        assertFalse(FileUtils.readFileToString(new File("build/unitTest/applications/app-service/build.gradle"), StandardCharsets.UTF_8)
+                .contains("compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
     }
 
     @Test

--- a/src/test/java/co/com/bancolombia/utils/UtilsTest.java
+++ b/src/test/java/co/com/bancolombia/utils/UtilsTest.java
@@ -158,6 +158,96 @@ public class UtilsTest {
     }
 
     @Test
+    public void shouldAddConfigurationAndConfigurationsBlock() {
+        // Arrange
+        String build = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}";
+        String expected = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}\n" +
+                "\n" +
+                "configurations{\n" +
+                "\tcompile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"\n" +
+                "}";
+        // Act
+        String result = Utils.addConfiguration(build, "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+        // Assert
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void shouldAddConfiguration() {
+        // Arrange
+        String build = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}\n" +
+                "\n" +
+                "configurations{\n" +
+                "\tcompile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"\n" +
+                "}";
+        String expected = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}\n" +
+                "\n" +
+                "configurations{\n" +
+                "\tcompile.exclude group: \"co.com.bancolombia\", module:\"excluded-module\"\n" +
+                "\tcompile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"\n" +
+                "}";
+        // Act
+        String result = Utils.addConfiguration(build, "compile.exclude group: \"co.com.bancolombia\", module:\"excluded-module\"");
+        // Assert
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void shouldNotAddConfigurationWhenExists() {
+        // Arrange
+        String build = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}\n" +
+                "\n" +
+                "configurations{\n" +
+                "\tcompile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"\n" +
+                "}";
+        String expected = "apply plugin: 'org.springframework.boot'\n" +
+                "\n" +
+                "dependencies {\n" +
+                "\timplementation project(':model')\n" +
+                "\timplementation project(':usecase')\n" +
+                "\tcompile 'org.springframework.boot:spring-boot-starter'\n" +
+                "}\n" +
+                "\n" +
+                "configurations{\n" +
+                "\tcompile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"\n" +
+                "}";
+        // Act
+        String result = Utils.addConfiguration(build, "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"");
+        // Assert
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void shouldGenerateDashName() {
         String res = Utils.toDashName("MyCamelCase");
         assertEquals("my-camel-case", res);


### PR DESCRIPTION
## Description
* Added a new optional parameter to create a rest mvc entry point called "--server", in which you can set one of the available server (Undertow, Tomcat or Jetty)

* Added a new utility to add configurations

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [x] The documentation is up-to-date
- [ ] the version of the build.gradle, readme.md and gradle.properties was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
