### PR TITLE
New Redis Driven Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    | mongodb                             | Mongo Repository     | --secret [true-false] |
    | asynceventbus                       | Async Event Bus      |                       |
    | restconsumer                        | Rest Client Consumer | --url [url]           |
+   | redis                               | Redis Template       | --secret [true-false] |
+   | redisrepository                     | Redis Repository     | --secret [true-false] |
 
    _**This task will generate something like that:**_
 

--- a/README.md
+++ b/README.md
@@ -177,15 +177,14 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    gradle gda --type [drivenAdapterType]
    ```
 
-   | Reference for **drivenAdapterType** | Name                 | Additional Options    |
-   | ----------------------------------- | -------------------- | --------------------- |
-   | generic                             | Empty Driven Adapter | --name [name]         |
-   | jpa                                 | JPA Repository       | --secret [true-false] |
-   | mongodb                             | Mongo Repository     | --secret [true-false] |
-   | asynceventbus                       | Async Event Bus      |                       |
-   | restconsumer                        | Rest Client Consumer | --url [url]           |
-   | redis                               | Redis Template       | --secret [true-false] |
-   | redisrepository                     | Redis Repository     | --secret [true-false] |
+   | Reference for **drivenAdapterType** | Name                 | Additional Options                                 |
+   | ----------------------------------- | -------------------- | -------------------------------------------------- |
+   | generic                             | Empty Driven Adapter | --name [name]                                      |
+   | jpa                                 | JPA Repository       | --secret [true-false]                              |
+   | mongodb                             | Mongo Repository     | --secret [true-false]                              |
+   | asynceventbus                       | Async Event Bus      |                                                    |
+   | restconsumer                        | Rest Client Consumer | --url [url]                                        |
+   | redis                               | Redis                | --mode [template-repository] --secret [true-false] |
 
    _**This task will generate something like that:**_
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.1"
+    id "co.com.bancolombia.cleanArchitecture" version "1.8.2"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.1f
+systemProp.version=1.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.1
+systemProp.version=1.8.1f

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
     public static final String SECRETS_VERSION = "2.1.0";
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.1";
+    public static final String PLUGIN_VERSION = "1.8.2";
     public static final String UNDERTOW_VERSION = "2.3.8.RELEASE";
     public static final String JETTY_VERSION = "2.3.8.RELEASE";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
@@ -12,7 +12,6 @@ public class DrivenAdapterJPA implements ModuleFactory {
         builder.loadPackage();
         builder.setupFromTemplate("driven-adapter/jpa-repository");
         builder.appendToSettings("jpa-repository", "infrastructure/driven-adapters");
-        builder.appendToSettings("jpa-repository-commons", "infrastructure/helpers");
         builder.appendToProperties("spring.datasource")
                 .put("url", "jdbc:h2:mem:test")
                 .put("username", "sa")

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -1,0 +1,46 @@
+package co.com.bancolombia.factory.adapters;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+import lombok.AllArgsConstructor;
+import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class DrivenAdapterRedis implements ModuleFactory {
+    private final Mode mode;
+
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+        Logger logger = builder.getProject().getLogger();
+        builder.loadPackage();
+        String typePath = getPathType(builder.isReactive());
+        String modePath = getPathMode();
+        logger.lifecycle("Generating {} in {} mode", typePath, modePath);
+        builder.setupFromTemplate("driven-adapter/" + typePath + "/" + modePath);
+        builder.appendToSettings("redis", "infrastructure/driven-adapters");
+        if (builder.getBooleanParam("include-secret")) {
+            builder.setupFromTemplate("driven-adapter/" + typePath + "/secret");
+        } else {
+            builder.appendToProperties("spring.redis")
+                    .put("host", "localhost")
+                    .put("port", 6379);
+        }
+        builder.appendDependencyToModule("app-service", "implementation project(':redis')");
+        new DrivenAdapterSecrets().buildModule(builder);
+    }
+
+    protected String getPathMode() {
+        return mode == Mode.REPOSITORY ? "redis-repository" : "redis-template";
+    }
+
+    protected String getPathType(boolean isReactive) {
+        return isReactive ? "redis-reactive" : "redis";
+    }
+
+    public enum Mode {
+        REPOSITORY, TEMPLATE
+    }
+}

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -10,14 +10,14 @@ import java.io.IOException;
 
 @AllArgsConstructor
 public class DrivenAdapterRedis implements ModuleFactory {
-    private final Mode mode;
+    public static final String PARAM_MODE = "task-param-mode";
 
     @Override
     public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
         Logger logger = builder.getProject().getLogger();
         builder.loadPackage();
         String typePath = getPathType(builder.isReactive());
-        String modePath = getPathMode();
+        String modePath = getPathMode((Mode) builder.getParam(PARAM_MODE));
         logger.lifecycle("Generating {} in {} mode", typePath, modePath);
         builder.setupFromTemplate("driven-adapter/" + typePath + "/" + modePath);
         builder.appendToSettings("redis", "infrastructure/driven-adapters");
@@ -32,7 +32,7 @@ public class DrivenAdapterRedis implements ModuleFactory {
         new DrivenAdapterSecrets().buildModule(builder);
     }
 
-    protected String getPathMode() {
+    protected String getPathMode(Mode mode) {
         return mode == Mode.REPOSITORY ? "redis-repository" : "redis-template";
     }
 

--- a/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
@@ -17,12 +17,16 @@ public class ModuleFactoryDrivenAdapter {
                 return new DrivenAdapterGeneric();
             case RESTCONSUMER:
                 return new DrivenAdapterRestConsumer();
+            case REDISREPOSITORY:
+                return new DrivenAdapterRedis(DrivenAdapterRedis.Mode.REPOSITORY);
+            case REDIS:
+                return new DrivenAdapterRedis(DrivenAdapterRedis.Mode.TEMPLATE);
             default:
                 throw new InvalidTaskOptionException("Driven Adapter type invalid");
         }
     }
 
     public enum DrivenAdapterType {
-        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER
+        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER, REDISREPOSITORY, REDIS
     }
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
@@ -17,16 +17,14 @@ public class ModuleFactoryDrivenAdapter {
                 return new DrivenAdapterGeneric();
             case RESTCONSUMER:
                 return new DrivenAdapterRestConsumer();
-            case REDISREPOSITORY:
-                return new DrivenAdapterRedis(DrivenAdapterRedis.Mode.REPOSITORY);
             case REDIS:
-                return new DrivenAdapterRedis(DrivenAdapterRedis.Mode.TEMPLATE);
+                return new DrivenAdapterRedis();
             default:
                 throw new InvalidTaskOptionException("Driven Adapter type invalid");
         }
     }
 
     public enum DrivenAdapterType {
-        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER, REDISREPOSITORY, REDIS
+        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER, REDIS
     }
 }

--- a/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
@@ -3,6 +3,7 @@ package co.com.bancolombia.task;
 import co.com.bancolombia.Constants.BooleanOption;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleFactory;
+import co.com.bancolombia.factory.adapters.DrivenAdapterRedis;
 import co.com.bancolombia.factory.adapters.ModuleFactoryDrivenAdapter;
 import co.com.bancolombia.factory.adapters.ModuleFactoryDrivenAdapter.DrivenAdapterType;
 import co.com.bancolombia.utils.Utils;
@@ -18,6 +19,7 @@ public class GenerateDrivenAdapterTask extends CleanArchitectureDefaultTask {
     private DrivenAdapterType type;
     private String name;
     private String url = "http://localhost:8080";
+    private DrivenAdapterRedis.Mode mode = DrivenAdapterRedis.Mode.TEMPLATE;
     private BooleanOption secret = BooleanOption.FALSE;
 
     @Option(option = "type", description = "Set type of driven adapter to be generated")
@@ -33,6 +35,11 @@ public class GenerateDrivenAdapterTask extends CleanArchitectureDefaultTask {
     @Option(option = "url", description = "Set driven adapter url when RESTCONSUMER type")
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    @Option(option = "mode", description = "Set template or reposiroty mode when REDIS type")
+    public void setMode(DrivenAdapterRedis.Mode mode) {
+        this.mode = mode;
     }
 
     @Option(option = "secret", description = "Enable secrets for this driven adapter")
@@ -62,6 +69,7 @@ public class GenerateDrivenAdapterTask extends CleanArchitectureDefaultTask {
         logger.lifecycle("Driven Adapter type: {}", type);
         builder.addParam("task-param-name", name);
         builder.addParam("include-secret", secret == BooleanOption.TRUE);
+        builder.addParam(DrivenAdapterRedis.PARAM_MODE, mode);
         builder.addParam("lombok", builder.isEnableLombok());
         builder.addParam("task-param-url", url);
         moduleFactory.buildModule(builder);

--- a/src/main/resources/driven-adapter/jpa-repository/config/db-secret.java.mustache
+++ b/src/main/resources/driven-adapter/jpa-repository/config/db-secret.java.mustache
@@ -48,7 +48,7 @@ public class DBSecret {
 
     @Override
     public String toString() {
-        return "MongoDBSecret{" +
+        return "DBSecret{" +
         "url='" + url + '\'' +
         ", username='" + username + '\'' +
         ", password='" + password + '\'' +

--- a/src/main/resources/driven-adapter/redis-reactive/redis-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-repository/build.gradle.mustache
@@ -1,0 +1,5 @@
+dependencies {
+    compile project(':model')
+    compile 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    compile 'org.reactivecommons.utils:object-mapper:0.1.0'
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-repository/definition.json
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-repository/definition.json
@@ -1,0 +1,11 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/redis/src/test/java/{{packagePath}}/redis/repository"
+  ],
+  "files": {
+    "driven-adapter/redis-reactive/redis-repository/helper/reactive-repository-adapter-operations.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/helper/ReactiveRepositoryAdapterOperations.java",
+    "driven-adapter/redis-reactive/redis-repository/reactive-redis-repository.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/ReactiveRedisRepository.java",
+    "driven-adapter/redis-reactive/redis-repository/reactive-redis-repository-adapter.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/ReactiveRedisRepositoryAdapter.java",
+    "driven-adapter/redis-reactive/redis-repository/build.gradle.mustache": "infrastructure/driven-adapters/redis/build.gradle"
+  }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-repository/helper/reactive-repository-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-repository/helper/reactive-repository-adapter-operations.java.mustache
@@ -1,0 +1,77 @@
+package {{package}}.redis.repository.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+import static org.springframework.data.domain.Example.of;
+
+public abstract class ReactiveRepositoryAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    public ReactiveRepositoryAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    public Mono<E> save(E entity) {
+        return Mono.just(entity)
+                .map(this::toData)
+                .flatMap(this::saveData)
+                .map(this::toEntity);
+    }
+
+    public Flux<E> saveAll(Flux<E> entities) {
+        return doQueryMany(repository.saveAll(entities.map(this::toData)));
+    }
+
+    public Mono<E> findById(I id) {
+        return doQuery(repository.findById(id));
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return doQueryMany(repository.findAll(of(toData(entity))));
+    }
+
+    public Mono<Void> deleteById(I id) {
+        return repository.deleteById(id);
+    }
+
+    public Flux<E> findAll() {
+        return doQueryMany(repository.findAll());
+    }
+
+    protected Mono<E> doQuery(Mono<D> query) {
+        return query.map(this::toEntity);
+    }
+
+    protected Flux<E> doQueryMany(Flux<D> query) {
+        return query.map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return toEntityFn.apply(data);
+    }
+
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-repository/reactive-redis-repository-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-repository/reactive-redis-repository-adapter.java.mustache
@@ -1,0 +1,20 @@
+package {{package}}.redis.repository;
+
+import {{package}}.redis.repository.helper.ReactiveRepositoryAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReactiveRedisRepositoryAdapter extends ReactiveRepositoryAdapterOperations<Object/* change for domain model */, Object/* change for adapter model */, String, ReactiveRedisRepository>
+// implements ModelRepository from domain
+{
+
+    public ReactiveRedisRepositoryAdapter(ReactiveRedisRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-repository/reactive-redis-repository.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-repository/reactive-redis-repository.java.mustache
@@ -1,0 +1,7 @@
+package {{package}}.redis.repository;
+
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface ReactiveRedisRepository extends ReactiveCrudRepository<Object/* change for adapter model */, String>, ReactiveQueryByExampleExecutor<Object/* change for adapter model */> {
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    compile project(':model')
+    compile 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    compile 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'org.reactivecommons.utils:object-mapper:0.1.0'
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/definition.json
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/redis/src/test/java/{{packagePath}}/redis/template"
+  ],
+  "files": {
+    "driven-adapter/redis-reactive/redis-template/helper/reactive-template-adapter-operations.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/template/helper/ReactiveTemplateAdapterOperations.java",
+    "driven-adapter/redis-reactive/redis-template/reactive-redis-template-adapter.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/template/ReactiveRedisTemplateAdapter.java",
+    "driven-adapter/redis-reactive/redis-template/build.gradle.mustache": "infrastructure/driven-adapters/redis/build.gradle"
+  }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/helper/reactive-template-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/helper/reactive-template-adapter-operations.java.mustache
@@ -1,0 +1,58 @@
+package {{package}}.redis.template.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveTemplateAdapterOperations<E, K, V> {
+    private final ReactiveRedisTemplate<K, V> template;
+    private final Class<V> dataClass;
+    protected ObjectMapper mapper;
+    private final Function<V, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    public ReactiveTemplateAdapterOperations(ReactiveRedisConnectionFactory connectionFactory, ObjectMapper mapper, Function<V, E> toEntityFn) {
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<V>) genericSuperclass.getActualTypeArguments()[2];
+        this.toEntityFn = toEntityFn;
+
+        RedisSerializationContext<K, V> serializationContext =
+                RedisSerializationContext.<K, V>newSerializationContext(new Jackson2JsonRedisSerializer<>(dataClass))
+                        .build();
+
+        template = new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+
+    public Mono<E> save(K key, E entity) {
+        return Mono.just(entity)
+                .map(this::toValue)
+                .flatMap(value -> template.opsForValue().set(key, value))
+                .thenReturn(entity);
+    }
+
+    public Mono<E> save(K key, E entity, long expirationMillis) {
+        return save(key, entity)
+                .flatMap(v -> template.expire(key, Duration.ofMillis(expirationMillis)).thenReturn(v));
+    }
+
+    public Mono<E> findById(K key) {
+        return template.opsForValue().get(key)
+                .map(this::toEntity);
+    }
+
+    protected V toValue(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(V data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/reactive-redis-template-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/reactive-redis-template-adapter.java.mustache
@@ -1,0 +1,21 @@
+package {{package}}.redis.template;
+
+import {{package}}.redis.template.helper.ReactiveTemplateAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class ReactiveRedisTemplateAdapter extends ReactiveTemplateAdapterOperations<Object/* change for domain model */, String, Object/* change for adapter model */>
+// implements ModelRepository from domain
+{
+    public ReactiveRedisTemplateAdapter(ReactiveRedisConnectionFactory connectionFactory, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(connectionFactory, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/secret/definition.json
+++ b/src/main/resources/driven-adapter/redis-reactive/secret/definition.json
@@ -1,0 +1,6 @@
+{
+  "folders": [],
+  "files": {
+    "driven-adapter/redis-reactive/secret/redis-config.java.mustache": "applications/app-service/src/main/java/{{packagePath}}/config/RedisConfig.java"
+  }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/secret/redis-config.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/secret/redis-config.java.mustache
@@ -1,0 +1,28 @@
+package {{package}}.config;
+
+import co.com.bancolombia.commons.secretsmanager.exceptions.SecretException;
+import co.com.bancolombia.commons.secretsmanager.manager.GenericManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisStandaloneConfiguration redisConfig(@Value("${aws.secretName}") String secret, GenericManager manager)
+            throws SecretException {
+        // Load secret here
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        // Update values here
+        return configuration;
+    }
+
+    @Bean
+    public ReactiveRedisConnectionFactory redisConnectionFactory(RedisStandaloneConfiguration configuration) {
+        return new LettuceConnectionFactory(configuration);
+    }
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
@@ -1,0 +1,5 @@
+dependencies {
+    compile project(':model')
+    compile 'org.springframework.boot:spring-boot-starter-data-redis'
+    compile 'org.reactivecommons.utils:object-mapper:0.1.0'
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/definition.json
+++ b/src/main/resources/driven-adapter/redis/redis-repository/definition.json
@@ -1,0 +1,11 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/redis/src/test/java/{{packagePath}}/redis/repository"
+  ],
+  "files": {
+    "driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/helper/RepositoryAdapterOperations.java",
+    "driven-adapter/redis/redis-repository/redis-repository.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/RedisRepository.java",
+    "driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/repository/RedisRepositoryAdapter.java",
+    "driven-adapter/redis/redis-repository/build.gradle.mustache": "infrastructure/driven-adapters/redis/build.gradle"
+  }
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache
@@ -1,0 +1,72 @@
+package {{package}}.redis.repository.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.StreamSupport.stream;
+
+public abstract class RepositoryAdapterOperations<E, D, I, R extends CrudRepository<D, I> & QueryByExampleExecutor<D>> {
+    protected R repository;
+    private final Class<D> dataClass;
+    protected ObjectMapper mapper;
+    private final Function<D, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    public RepositoryAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public E save(E entity) {
+        D data = toData(entity);
+        return toEntity(saveData(data));
+    }
+
+    protected List<E> saveAllEntities(List<E> entities) {
+        List<D> list = entities.stream().map(this::toData).collect(Collectors.toList());
+        return toList(saveData(list));
+    }
+
+    public List<E> toList(Iterable<D> iterable) {
+        return stream(iterable.spliterator(), false).map(this::toEntity).collect(Collectors.toList());
+    }
+
+    protected D saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Iterable<D> saveData(List<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public E findById(I id) {
+        return toEntity(repository.findById(id).orElse(null));
+    }
+
+    public List<E> findByExample(E entity) {
+        return toList(repository.findAll( Example.of(toData(entity))));
+    }
+
+
+    public List<E> findAll(){
+        return toList(repository.findAll());
+    }
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache
@@ -1,0 +1,20 @@
+package {{package}}.redis.repository;
+
+import {{package}}.redis.repository.helper.RepositoryAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RedisRepositoryAdapter extends RepositoryAdapterOperations<Object/* change for domain model */, Object/* change for adapter model */, String, RedisRepository>
+// implements ModelRepository from domain
+{
+
+    public RedisRepositoryAdapter(RedisRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/redis-repository.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/redis-repository.java.mustache
@@ -1,0 +1,7 @@
+package {{package}}.redis.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.QueryByExampleExecutor;
+
+public interface RedisRepository extends CrudRepository<Object/* change for adapter model */, String>, QueryByExampleExecutor<Object/* change for adapter model */> {
+}

--- a/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    compile project(':model')
+    compile 'org.springframework.boot:spring-boot-starter-data-redis'
+    compile 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'org.reactivecommons.utils:object-mapper:0.1.0'
+}

--- a/src/main/resources/driven-adapter/redis/redis-template/definition.json
+++ b/src/main/resources/driven-adapter/redis/redis-template/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/redis/src/test/java/{{packagePath}}/redis/template"
+  ],
+  "files": {
+    "driven-adapter/redis/redis-template/helper/template-adapter-operations.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/template/helper/TemplateAdapterOperations.java",
+    "driven-adapter/redis/redis-template/redis-template-adapter.java.mustache": "infrastructure/driven-adapters/redis/src/main/java/{{packagePath}}/redis/template/RedisTemplateAdapter.java",
+    "driven-adapter/redis/redis-template/build.gradle.mustache": "infrastructure/driven-adapters/redis/build.gradle"
+  }
+}

--- a/src/main/resources/driven-adapter/redis/redis-template/helper/template-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/helper/template-adapter-operations.java.mustache
@@ -1,0 +1,53 @@
+package {{package}}.redis.template.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class TemplateAdapterOperations<E, K, V> {
+    private final RedisTemplate<K, V> template;
+    private final Class<V> dataClass;
+    protected ObjectMapper mapper;
+    private final Function<V, E> toEntityFn;
+
+    @SuppressWarnings("unchecked")
+    public TemplateAdapterOperations(RedisConnectionFactory connectionFactory, ObjectMapper mapper, Function<V, E> toEntityFn) {
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<V>) genericSuperclass.getActualTypeArguments()[2];
+        this.toEntityFn = toEntityFn;
+
+        template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setDefaultSerializer(new Jackson2JsonRedisSerializer<>(dataClass));
+        template.afterPropertiesSet();
+    }
+
+    public E save(K key, E entity) {
+        template.opsForValue().set(key, toValue(entity));
+        return entity;
+    }
+
+    public E save(K key, E entity, long expirationMillis) {
+        E result = save(key, entity);
+        template.expire(key, Duration.ofMillis(expirationMillis));
+        return result;
+    }
+
+    public E findById(K key) {
+        return toEntity(template.opsForValue().get(key));
+    }
+
+    protected V toValue(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(V data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+}

--- a/src/main/resources/driven-adapter/redis/redis-template/redis-template-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/redis-template-adapter.java.mustache
@@ -1,0 +1,21 @@
+package {{package}}.redis.template;
+
+import {{package}}.redis.template.helper.TemplateAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisTemplateAdapter extends TemplateAdapterOperations<Object/* change for domain model */, String, Object/* change for adapter model */>
+// implements ModelRepository from domain
+{
+    public RedisTemplateAdapter(RedisConnectionFactory connectionFactory, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(connectionFactory, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+
+}

--- a/src/main/resources/driven-adapter/redis/secret/definition.json
+++ b/src/main/resources/driven-adapter/redis/secret/definition.json
@@ -1,0 +1,6 @@
+{
+  "folders": [],
+  "files": {
+    "driven-adapter/redis/secret/redis-config.java.mustache": "applications/app-service/src/main/java/{{packagePath}}/config/RedisConfig.java"
+  }
+}

--- a/src/main/resources/driven-adapter/redis/secret/redis-config.java.mustache
+++ b/src/main/resources/driven-adapter/redis/secret/redis-config.java.mustache
@@ -1,0 +1,28 @@
+package {{package}}.config;
+
+import co.com.bancolombia.commons.secretsmanager.exceptions.SecretException;
+import co.com.bancolombia.commons.secretsmanager.manager.GenericManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisStandaloneConfiguration redisConfig(@Value("${aws.secretName}") String secret, GenericManager manager)
+            throws SecretException {
+        // Load secret here
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        // Update values here
+        return configuration;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(RedisStandaloneConfiguration configuration) {
+        return new LettuceConnectionFactory(configuration);
+    }
+}

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -215,6 +215,64 @@ public class GenerateDrivenAdapterTaskTest {
         assertEquals(2, options.size());
     }
 
+    @Test
+    public void generateDrivenAdapterRedisRepositoryForImperative() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDISREPOSITORY);
+        // Act
+        task.generateDrivenAdapterTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/RepositoryAdapterOperations.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepository.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepositoryAdapter.java").exists());
+    }
+
+    @Test
+    public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDISREPOSITORY);
+        task.setSecret(Constants.BooleanOption.TRUE);
+        // Act
+        task.generateDrivenAdapterTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/ReactiveRepositoryAdapterOperations.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/ReactiveRedisRepository.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/ReactiveRedisRepositoryAdapter.java").exists());
+        assertTrue(new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/RedisConfig.java").exists());
+    }
+
+    @Test
+    public void generateDrivenAdapterRedisTemplateForImperative() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDIS);
+        // Act
+        task.generateDrivenAdapterTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/helper/TemplateAdapterOperations.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/RedisTemplateAdapter.java").exists());
+    }
+
+    @Test
+    public void generateDrivenAdapterRedisTemplateForReactiveWithSecret() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDIS);
+        task.setSecret(Constants.BooleanOption.TRUE);
+        // Act
+        task.generateDrivenAdapterTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/helper/ReactiveTemplateAdapterOperations.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/ReactiveRedisTemplateAdapter.java").exists());
+        assertTrue(new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/RedisConfig.java").exists());
+    }
+
     private void writeString(File file, String string) throws IOException {
         try (Writer writer = new FileWriter(file)) {
             writer.write(string);

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -2,6 +2,7 @@ package co.com.bancolombia.task;
 
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.adapters.DrivenAdapterRedis;
 import co.com.bancolombia.factory.adapters.ModuleFactoryDrivenAdapter;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -219,7 +220,8 @@ public class GenerateDrivenAdapterTaskTest {
     public void generateDrivenAdapterRedisRepositoryForImperative() throws IOException, CleanException {
         // Arrange
         setup(GenerateStructureTask.ProjectType.IMPERATIVE);
-        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDISREPOSITORY);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDIS);
+        task.setMode(DrivenAdapterRedis.Mode.REPOSITORY);
         // Act
         task.generateDrivenAdapterTask();
         // Assert
@@ -233,7 +235,8 @@ public class GenerateDrivenAdapterTaskTest {
     public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret() throws IOException, CleanException {
         // Arrange
         setup(GenerateStructureTask.ProjectType.REACTIVE);
-        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDISREPOSITORY);
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.REDIS);
+        task.setMode(DrivenAdapterRedis.Mode.REPOSITORY);
         task.setSecret(Constants.BooleanOption.TRUE);
         // Act
         task.generateDrivenAdapterTask();


### PR DESCRIPTION
## Description
Implementation of a new driven adapter for Redis, it's available for reactive and non reactive projects.

The Redis driven adapter implementation supports RedisRepository and RedisTemplate modes all from spring data starter.

## Category
- [x] Feature that resolves #110 
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the build.gradle, readme.md and gradle.properties was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
