### PR TITLE
Feature/rsocket components Driven adapter and Entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.4"
+    id "co.com.bancolombia.cleanArchitecture" version "1.8.5"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.2"
+    id "co.com.bancolombia.cleanArchitecture" version "1.8.4"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.3
+systemProp.version=1.8.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.2
+systemProp.version=1.8.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.4
+systemProp.version=1.8.5

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -261,7 +261,7 @@ public class PluginCleanFunctionalTest {
 
     @Test
     public void canRunTaskGenerateDrivenAdapterRsocketRequesterCase() {
-        canRunTaskGenerateStructureWithOutParameters();
+        canRunTaskGenerateStructureReactiveProject();
         String task = "generateDrivenAdapter";
         String valueDrivenAdapter = "rsocket";
 
@@ -277,7 +277,7 @@ public class PluginCleanFunctionalTest {
 
     @Test
     public void canRunTaskGenerateEntryPointrRsocketResponderCase() {
-        canRunTaskGenerateStructureWithOutParameters();
+        canRunTaskGenerateStructureReactiveProject();
         String task = "generateEntryPoint";
         String valueDrivenAdapter = "rsocket";
 

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -260,6 +260,37 @@ public class PluginCleanFunctionalTest {
     }
 
     @Test
+    public void canRunTaskGenerateDrivenAdapterRsocketRequesterCase() {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateDrivenAdapter";
+        String valueDrivenAdapter = "rsocket";
+
+        runner.withArguments(task, "--type=" + valueDrivenAdapter);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/rsocket-requester/build.gradle").exists());
+        assertTrue(new File("build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/config/RequesterConfig.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/rsocket-requester/src/main/java/co/com/bancolombia/service/RsocketAdapter.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/rsocket-requester/src/test/java/co/com/bancolombia/service").exists());
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canRunTaskGenerateEntryPointrRsocketResponderCase() {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueDrivenAdapter = "rsocket";
+
+        runner.withArguments(task, "--type=" + valueDrivenAdapter);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/rsocket-responder/build.gradle").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/rsocket-responder/src/main/java/co/com/bancolombia/controller/RsocketController.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/rsocket-responder/src/test/java/co/com/bancolombia/controller").exists());
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
     public void canRunTaskGenerateEntryPointCaseWithParameters() {
         canRunTaskGenerateStructureWithOutParameters();
         String task = "generateEntryPoint";

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
     public static final String SECRETS_VERSION = "2.1.0";
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.3";
+    public static final String PLUGIN_VERSION = "1.8.4";
     public static final String UNDERTOW_VERSION = "2.3.8.RELEASE";
     public static final String JETTY_VERSION = "2.3.8.RELEASE";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
     public static final String SECRETS_VERSION = "2.1.0";
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.4";
+    public static final String PLUGIN_VERSION = "1.8.5";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
 
     public enum BooleanOption {

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
     public static final String SECRETS_VERSION = "2.1.0";
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.2";
+    public static final String PLUGIN_VERSION = "1.8.3";
     public static final String UNDERTOW_VERSION = "2.3.8.RELEASE";
     public static final String JETTY_VERSION = "2.3.8.RELEASE";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRsocketRequester.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRsocketRequester.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.factory.adapters;
 
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.exceptions.InvalidTaskOptionException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 
@@ -11,9 +12,14 @@ public class DrivenAdapterRsocketRequester implements ModuleFactory {
     @Override
     public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
         builder.loadPackage();
-        builder.appendToSettings("rsocket-requester", "infrastructure/driven-adapters");
-        builder.appendDependencyToModule("app-service",
-                "implementation project(':rsocket-requester')");
-        builder.setupFromTemplate("driven-adapter/rsocket-requester");
+        if (builder.isReactive()) {
+            builder.appendToSettings("rsocket-requester", "infrastructure/driven-adapters");
+            builder.appendDependencyToModule("app-service",
+                    "implementation project(':rsocket-requester')");
+            builder.setupFromTemplate("driven-adapter/rsocket-requester");
+        } else {
+            throw new InvalidTaskOptionException("Rsocket requester Driven Adapter is only available in reactive projects");
+        }
+
     }
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRsocketRequester.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRsocketRequester.java
@@ -1,0 +1,19 @@
+package co.com.bancolombia.factory.adapters;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+
+import java.io.IOException;
+
+public class DrivenAdapterRsocketRequester implements ModuleFactory {
+
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+        builder.loadPackage();
+        builder.appendToSettings("rsocket-requester", "infrastructure/driven-adapters");
+        builder.appendDependencyToModule("app-service",
+                "implementation project(':rsocket-requester')");
+        builder.setupFromTemplate("driven-adapter/rsocket-requester");
+    }
+}

--- a/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/ModuleFactoryDrivenAdapter.java
@@ -19,12 +19,14 @@ public class ModuleFactoryDrivenAdapter {
                 return new DrivenAdapterRestConsumer();
             case REDIS:
                 return new DrivenAdapterRedis();
+            case RSOCKET:
+                return new DrivenAdapterRsocketRequester();
             default:
                 throw new InvalidTaskOptionException("Driven Adapter type invalid");
         }
     }
 
     public enum DrivenAdapterType {
-        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER, REDIS
+        JPA, MONGODB, ASYNCEVENTBUS, GENERIC, RESTCONSUMER, REDIS, RSOCKET
     }
 }

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRsocketResponder.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRsocketResponder.java
@@ -1,0 +1,22 @@
+package co.com.bancolombia.factory.entrypoints;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+
+import java.io.IOException;
+
+public class EntryPointRsocketResponder implements ModuleFactory {
+
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+        builder.loadPackage();
+        builder.appendToSettings("rsocket-responder", "infrastructure/entry-points");
+        builder.appendToProperties("spring.rsocket.server")
+                .put("port", 7000);
+        builder.appendDependencyToModule("app-service",
+                "implementation project(':rsocket-responder')");
+        builder.setupFromTemplate("entry-point/rsocket-responder");
+    }
+
+}

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRsocketResponder.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRsocketResponder.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.factory.entrypoints;
 
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.exceptions.InvalidTaskOptionException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 
@@ -11,12 +12,17 @@ public class EntryPointRsocketResponder implements ModuleFactory {
     @Override
     public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
         builder.loadPackage();
-        builder.appendToSettings("rsocket-responder", "infrastructure/entry-points");
-        builder.appendToProperties("spring.rsocket.server")
-                .put("port", 7000);
-        builder.appendDependencyToModule("app-service",
-                "implementation project(':rsocket-responder')");
-        builder.setupFromTemplate("entry-point/rsocket-responder");
+        if (builder.isReactive()) {
+            builder.appendToSettings("rsocket-responder", "infrastructure/entry-points");
+            builder.appendToProperties("spring.rsocket.server")
+                    .put("port", 7000);
+            builder.appendDependencyToModule("app-service",
+                    "implementation project(':rsocket-responder')");
+            builder.setupFromTemplate("entry-point/rsocket-responder");
+        } else {
+            throw new InvalidTaskOptionException("Rsocket responder Entry Point is only available in reactive projects");
+        }
+
     }
 
 }

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
@@ -13,12 +13,14 @@ public class ModuleFactoryEntryPoint {
                 return new EntryPointRestWebflux();
             case GENERIC:
                 return new EntryPointGeneric();
+            case RSOCKET:
+                return new EntryPointRsocketResponder();
             default:
                 throw new InvalidTaskOptionException("Entry Point type invalid");
         }
     }
 
     public enum EntryPointType {
-        RESTMVC, WEBFLUX, GENERIC
+        RESTMVC, WEBFLUX, GENERIC, RSOCKET
     }
 }

--- a/src/main/resources/driven-adapter/rsocket-requester/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework:spring-context'
+    compile 'org.springframework.boot:spring-boot-starter-rsocket'
+}

--- a/src/main/resources/driven-adapter/rsocket-requester/config/requester-config.java.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/config/requester-config.java.mustache
@@ -1,0 +1,27 @@
+package {{package}}.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.cbor.Jackson2CborDecoder;
+import org.springframework.http.codec.cbor.Jackson2CborEncoder;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.messaging.rsocket.RSocketStrategies;
+
+@Configuration
+public class RequesterConfig {
+
+    @Bean
+    public RSocketRequester rSocketRequester(RSocketStrategies rSocketStrategies) {
+        RSocketStrategies strategies = RSocketStrategies.builder()
+            .encoders(encoders -> encoders.add(new Jackson2CborEncoder()))
+            .decoders(decoders -> decoders.add(new Jackson2CborDecoder()))
+            .build();
+        return RSocketRequester.builder()
+            .rsocketStrategies(strategies)
+            .dataMimeType(MediaType.APPLICATION_CBOR)
+            .connectTcp("localhost",7000) // server IP or DNS, and port
+            .block();
+    }
+
+}

--- a/src/main/resources/driven-adapter/rsocket-requester/config/requester-config.java.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/config/requester-config.java.mustache
@@ -20,8 +20,7 @@ public class RequesterConfig {
         return RSocketRequester.builder()
             .rsocketStrategies(strategies)
             .dataMimeType(MediaType.APPLICATION_CBOR)
-            .connectTcp("localhost",7000) // server IP or DNS, and port
-            .block();
+            .tcp("localhost",7000); // server IP or DNS, and port
     }
 
 }

--- a/src/main/resources/driven-adapter/rsocket-requester/definition.json
+++ b/src/main/resources/driven-adapter/rsocket-requester/definition.json
@@ -1,0 +1,11 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/rsocket-requester/src/main/java/{{packagePath}}/service",
+    "infrastructure/driven-adapters/rsocket-requester/src/test/java/{{packagePath}}/service"
+  ],
+  "files": {
+    "driven-adapter/rsocket-requester/config/requester-config.java.mustache": "applications/app-service/src/main/java/{{packagePath}}/config/RequesterConfig.java",
+    "driven-adapter/rsocket-requester/build.gradle.mustache": "infrastructure/driven-adapters/rsocket-requester/build.gradle",
+    "driven-adapter/rsocket-requester/rsocket-requester.java.mustache": "infrastructure/driven-adapters/rsocket-requester/src/main/java/{{packagePath}}/service/RsocketAdapter.java"
+  }
+}

--- a/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
@@ -14,14 +14,11 @@ import org.springframework.messaging.rsocket.RSocketRequester;
 {{/lombok}}
 public class RsocketAdapter // implements Gateway from domain
 {
-    {{#lombok}}
-    private final RSocketRequester rSocketRequester;
-    {{/lombok}}
 
+    private final RSocketRequester rSocketRequester;
     {{^lombok}}
-    private final RSocketRequester rSocketRequester;
 
-    public BlogRequester(RSocketRequester rSocketRequester) {
+    public RsocketAdapter(RSocketRequester rSocketRequester) {
         this.rSocketRequester = rSocketRequester;
     }
     {{/lombok}}

--- a/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
@@ -1,0 +1,64 @@
+package {{package}}.service;
+
+{{#lombok}}
+import lombok.RequiredArgsConstructor;
+{{/lombok}}
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import org.springframework.messaging.rsocket.RSocketRequester;
+
+@Service
+{{#lombok}}
+@RequiredArgsConstructor
+{{/lombok}}
+public class RsocketAdapter // implements Gateway from domain
+{
+    {{#lombok}}
+    private final RSocketRequester rSocketRequester;
+    {{/lombok}}
+
+    {{^lombok}}
+    private final RSocketRequester rSocketRequester;
+
+    public BlogRequester(RSocketRequester rSocketRequester) {
+        this.rSocketRequester = rSocketRequester;
+    }
+    {{/lombok}}
+
+    // interaction model Request/Response
+    public Mono<Object/* change for object response */> callRouteRequest(Object objRequest/* change for object request */) {
+        return this.rSocketRequester
+            .route("route.request.response")
+            .data(objRequest)
+            .retrieveMono(Object.class)
+            .log();
+    }
+
+    // interaction model Fire-and-Forget
+    public void callRouteFireForget(Object objRequest/* change for object request */) {
+        this.rSocketRequester
+            .route("route.fire.forget")
+            .data(objRequest)
+            .send()
+            .log()
+            .subscribe();
+    }
+
+    // interaction model Request/Stream
+    public Flux<Object/* change for object response */> callRouteRequestStream() {
+        return this.rSocketRequester
+            .route("route.request.stream")
+            .retrieveFlux(Object.class)
+            .log();
+    }
+
+    // interaction model Channel
+    public Flux<Object/* change for object response */> callRouteChannel(Flux<Object/* change for object request */> objRequest) {
+        return this.rSocketRequester
+            .route("route.channel")
+            .data(objRequest)
+            .retrieveFlux(Object.class)
+            .log();
+    }
+}

--- a/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
+++ b/src/main/resources/driven-adapter/rsocket-requester/rsocket-requester.java.mustache
@@ -36,13 +36,12 @@ public class RsocketAdapter // implements Gateway from domain
     }
 
     // interaction model Fire-and-Forget
-    public void callRouteFireForget(Object objRequest/* change for object request */) {
-        this.rSocketRequester
+    public Mono<Void> callRouteFireForget(Object objRequest/* change for object request */) {
+        return this.rSocketRequester
             .route("route.fire.forget")
             .data(objRequest)
             .send()
-            .log()
-            .subscribe();
+            .log();
     }
 
     // interaction model Request/Stream

--- a/src/main/resources/entry-point/rsocket-responder/build.gradle.mustache
+++ b/src/main/resources/entry-point/rsocket-responder/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-rsocket'
+}

--- a/src/main/resources/entry-point/rsocket-responder/definition.json
+++ b/src/main/resources/entry-point/rsocket-responder/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    "infrastructure/entry-points/rsocket-responder/src/main/java/{{packagePath}}/controller",
+    "infrastructure/entry-points/rsocket-responder/src/test/java/{{packagePath}}/controller"
+  ],
+  "files": {
+    "entry-point/rsocket-responder/build.gradle.mustache": "infrastructure/entry-points/rsocket-responder/build.gradle",
+    "entry-point/rsocket-responder/rsocket-responder.java.mustache": "infrastructure/entry-points/rsocket-responder/src/main/java/{{packagePath}}/controller/RsocketController.java"
+  }
+}

--- a/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
+++ b/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
@@ -24,6 +24,7 @@ public class RsocketController {
         this.useCase = useCase;
     }*/
 {{/lombok}}
+
     // interaction model Request/Response
     @MessageMapping(value = "route.request.response")
     public Mono<Object/* change for object response */> getRequestResponse(Object objRequest/* change for object request */) {
@@ -40,8 +41,9 @@ public class RsocketController {
 
     // interaction model Fire-and-Forget
     @MessageMapping(value = "route.fire.forget")
-    public void getRequetsFireForget(Object objRequest/* change for object request */) {
+    public Mono<Void> getRequetsFireForget(Object objRequest/* change for object request */) {
         // return useCase.doAction(objRequest);
+        return Mono.empty();
     }
 
     // interaction model Channel

--- a/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
+++ b/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
@@ -1,0 +1,46 @@
+package {{package}}.controller;
+
+{{#lombok}}
+    import lombok.RequiredArgsConstructor;
+{{/lombok}}
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Controller
+{{#lombok}}
+    @RequiredArgsConstructor
+{{/lombok}}
+public class RsocketController {
+
+//  private final MyUseCase useCase;
+
+    // interaction model Request/Response
+    @MessageMapping(value = "route.request.response")
+    public Mono<Object/* change for object response */> addBlog(Object objRequest/* change for object request */) {
+        // return useCase.doAction();
+        return Mono.empty();
+    }
+
+    // interaction model Request/Stream
+    @MessageMapping(value = "route.request.stream")
+    public Flux<Object/* change for object response */> getAllBlog() {
+        // return useCase.doAction();
+        return Flux.empty();
+    }
+
+    // interaction model Fire-and-Forget
+    @MessageMapping(value = "route.fire.forget")
+    public void addBlogFireAndForget(Object objRequest/* change for object request */) {
+        // return useCase.doAction(objRequest);
+    }
+
+    // interaction model Channel
+    @MessageMapping(value = "route.channel")
+    public Flux<Object/* change for object response */> testChannel(Flux<Object/* change for object request */> objRequest) {
+        // return useCase.doAction(objRequest);
+        return Flux.empty();
+    }
+
+}

--- a/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
+++ b/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
@@ -1,7 +1,7 @@
 package {{package}}.controller;
 
 {{#lombok}}
-    import lombok.RequiredArgsConstructor;
+import lombok.RequiredArgsConstructor;
 {{/lombok}}
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
@@ -10,35 +10,43 @@ import reactor.core.publisher.Mono;
 
 @Controller
 {{#lombok}}
-    @RequiredArgsConstructor
+@RequiredArgsConstructor
 {{/lombok}}
 public class RsocketController {
 
-//  private final MyUseCase useCase;
+{{#lombok}}
+    // private final MyUseCase useCase;
+{{/lombok}}
+{{^lombok}}
+    /*private MyUseCase useCase;
 
+    public BlogController(MyUseCase useCase) {
+        this.useCase = useCase;
+    }*/
+{{/lombok}}
     // interaction model Request/Response
     @MessageMapping(value = "route.request.response")
-    public Mono<Object/* change for object response */> addBlog(Object objRequest/* change for object request */) {
+    public Mono<Object/* change for object response */> getRequestResponse(Object objRequest/* change for object request */) {
         // return useCase.doAction();
         return Mono.empty();
     }
 
     // interaction model Request/Stream
     @MessageMapping(value = "route.request.stream")
-    public Flux<Object/* change for object response */> getAllBlog() {
+    public Flux<Object/* change for object response */> getRequestStream() {
         // return useCase.doAction();
         return Flux.empty();
     }
 
     // interaction model Fire-and-Forget
     @MessageMapping(value = "route.fire.forget")
-    public void addBlogFireAndForget(Object objRequest/* change for object request */) {
+    public void getRequetsFireForget(Object objRequest/* change for object request */) {
         // return useCase.doAction(objRequest);
     }
 
     // interaction model Channel
     @MessageMapping(value = "route.channel")
-    public Flux<Object/* change for object response */> testChannel(Flux<Object/* change for object request */> objRequest) {
+    public Flux<Object/* change for object response */> getChannel(Flux<Object/* change for object request */> objRequest) {
         // return useCase.doAction(objRequest);
         return Flux.empty();
     }

--- a/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
+++ b/src/main/resources/entry-point/rsocket-responder/rsocket-responder.java.mustache
@@ -14,13 +14,10 @@ import reactor.core.publisher.Mono;
 {{/lombok}}
 public class RsocketController {
 
-{{#lombok}}
     // private final MyUseCase useCase;
-{{/lombok}}
 {{^lombok}}
-    /*private MyUseCase useCase;
 
-    public BlogController(MyUseCase useCase) {
+    /*public RsocketController(MyUseCase useCase) {
         this.useCase = useCase;
     }*/
 {{/lombok}}

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -103,6 +103,7 @@ public class GenerateDrivenAdapterTaskTest {
     @Test
     public void generateRsocketRequester() throws IOException, CleanException {
         // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
         task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.RSOCKET);
         // Act
         task.generateDrivenAdapterTask();

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -101,6 +101,19 @@ public class GenerateDrivenAdapterTaskTest {
     }
 
     @Test
+    public void generateRsocketRequester() throws IOException, CleanException {
+        // Arrange
+        task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.RSOCKET);
+        // Act
+        task.generateDrivenAdapterTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/rsocket-requester/build.gradle").exists());
+        assertTrue(new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/RequesterConfig.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/rsocket-requester/src/main/java/co/com/bancolombia/service/RsocketAdapter.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/rsocket-requester/src/test/java/co/com/bancolombia/service").exists());
+    }
+
+    @Test
     public void generateDrivenAdapterJPARepository() throws IOException, CleanException {
         // Arrange
         task.setType(ModuleFactoryDrivenAdapter.DrivenAdapterType.JPA);

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -107,6 +107,18 @@ public class GenerateEntryPointTaskTest {
     }
 
     @Test
+    public void generateEntryPointRsocketResponder() throws IOException, CleanException {
+        // Arrange
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.RSOCKET);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/rsocket-responder/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/rsocket-responder/src/main/java/co/com/bancolombia/controller/RsocketController.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/rsocket-responder/src/test/java/co/com/bancolombia/controller").exists());
+    }
+
+    @Test
     public void generateEntryPointApiRestWithDefaultServer() throws IOException, CleanException {
         // Arrange
         task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -27,11 +27,16 @@ public class GenerateEntryPointTaskTest {
     private GenerateEntryPointTask task;
 
     @Before
-    public void setup() throws IOException, CleanException {
+    public void init() throws IOException, CleanException {
+        setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+    }
+
+    public void setup(GenerateStructureTask.ProjectType type) throws IOException, CleanException {
         Project project = ProjectBuilder.builder().withProjectDir(new File("build/unitTest")).build();
         deleteStructure(project.getProjectDir().toPath());
         project.getTasks().create("ca", GenerateStructureTask.class);
         GenerateStructureTask caTask = (GenerateStructureTask) project.getTasks().getByName("ca");
+        caTask.setType(type);
         caTask.generateStructureTask();
 
         ProjectBuilder.builder()
@@ -109,6 +114,7 @@ public class GenerateEntryPointTaskTest {
     @Test
     public void generateEntryPointRsocketResponder() throws IOException, CleanException {
         // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
         task.setType(ModuleFactoryEntryPoint.EntryPointType.RSOCKET);
         // Act
         task.generateEntryPointTask();
@@ -185,6 +191,7 @@ public class GenerateEntryPointTaskTest {
     @Test
     public void generateEntryPointReactiveWebWithoutRouterFunctions() throws IOException, CleanException {
         // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
         task.setType(ModuleFactoryEntryPoint.EntryPointType.WEBFLUX);
         task.setRouter(Constants.BooleanOption.FALSE);
         // Act
@@ -199,6 +206,7 @@ public class GenerateEntryPointTaskTest {
     @Test
     public void generateEntryPointReactiveWebWithRouterFunctions() throws IOException, CleanException {
         // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
         task.setType(ModuleFactoryEntryPoint.EntryPointType.WEBFLUX);
         task.setRouter(Constants.BooleanOption.TRUE);
 
@@ -213,6 +221,7 @@ public class GenerateEntryPointTaskTest {
     @Test
     public void generateEntryPointReactiveWebWithDefaultOptionFunctions() throws IOException, CleanException {
         // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
         task.setType(ModuleFactoryEntryPoint.EntryPointType.WEBFLUX);
 
         // Act


### PR DESCRIPTION
## Description
New feature: Users can create driven adapter and entry point of the Rsocket type, in order to establish communication through the Rsocket protocol.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the build.gradle, readme.md and gradle.properties was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
