### PR TITLE
Feature/graphql server

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow    |
    | webflux                          | API REST (Spring Boot Starter WebFlux) | --router [true, false] default true      |
    | rsocket                          | Rsocket Controller Entry Point         |                            |
-   | graphql                          | API GraphQL (Default path /graphql)    | --pathgql [name path]                       |
+   | graphql                          | API GraphQL    | --pathgql [name path] default /graphql                      |
 
    Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.5"
+    id "co.com.bancolombia.cleanArchitecture" version "1.8.6"
 }
 ```
 
@@ -229,6 +229,7 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow    |
    | webflux                          | API REST (Spring Boot Starter WebFlux) | --router [true, false] default true      |
    | rsocket                          | Rsocket Controller Entry Point         |                            |
+   | graphql                          | API GraphQL (Default path /graphql)    | --pathgql [name path]                       |
 
    Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.5
+systemProp.version=1.8.6

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -260,6 +260,23 @@ public class PluginCleanFunctionalTest {
     }
 
     @Test
+    public void canRunTaskGenerateEntryPointGrahpqlApiCase() {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueEntryPoint = "graphql";
+        String valuePathgqlEntryPoint = "/graphqlpath";
+
+        runner.withArguments(task, "--type=" + valueEntryPoint, "--pathgql=" + valuePathgqlEntryPoint);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/graphql-api/build.gradle").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiQueries.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiMutations.java").exists());
+
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
     public void canRunTaskGenerateDrivenAdapterRsocketRequesterCase() {
         canRunTaskGenerateStructureReactiveProject();
         String task = "generateDrivenAdapter";

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
     public static final String SECRETS_VERSION = "2.1.0";
     public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.5";
+    public static final String PLUGIN_VERSION = "1.8.6";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
 
     public enum BooleanOption {

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointGraphql.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointGraphql.java
@@ -1,0 +1,34 @@
+package co.com.bancolombia.factory.entrypoints;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.exceptions.InvalidTaskOptionException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+
+import java.io.IOException;
+
+public class EntryPointGraphql implements ModuleFactory {
+
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+        builder.loadPackage();
+        String name = builder.getStringParam("task-param-pathgql");
+        if (!name.startsWith("/")) {
+            throw new IllegalArgumentException("The path must start with /");
+        }
+        if (!builder.isReactive()) {
+            builder.appendToSettings("graphql-api", "infrastructure/entry-points");
+            builder.appendToProperties("graphql.servlet")
+                    .put("enabled", true)
+                    .put("mapping", name);
+            builder.appendToProperties("graphql.playground")
+                    .put("mapping", "/playground")
+                    .put("endpoint", name);
+            builder.appendDependencyToModule("app-service",
+                    "implementation project(':graphql-api')");
+            builder.setupFromTemplate("entry-point/graphql-api");
+        } else {
+            throw new InvalidTaskOptionException("Graphql API is only available on imperative projects");
+        }
+    }
+}

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointGraphql.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointGraphql.java
@@ -6,6 +6,7 @@ import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class EntryPointGraphql implements ModuleFactory {
 
@@ -23,7 +24,8 @@ public class EntryPointGraphql implements ModuleFactory {
                     .put("mapping", name);
             builder.appendToProperties("graphql.playground")
                     .put("mapping", "/playground")
-                    .put("endpoint", name);
+                    .put("endpoint", name)
+                    .put("enabled", true);
             builder.appendDependencyToModule("app-service",
                     "implementation project(':graphql-api')");
             builder.setupFromTemplate("entry-point/graphql-api");

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
@@ -15,12 +15,14 @@ public class ModuleFactoryEntryPoint {
                 return new EntryPointGeneric();
             case RSOCKET:
                 return new EntryPointRsocketResponder();
+            case GRAPHQL:
+                return new EntryPointGraphql();
             default:
                 throw new InvalidTaskOptionException("Entry Point type invalid");
         }
     }
 
     public enum EntryPointType {
-        RESTMVC, WEBFLUX, GENERIC, RSOCKET
+        RESTMVC, WEBFLUX, GENERIC, RSOCKET, GRAPHQL
     }
 }

--- a/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
@@ -19,6 +19,7 @@ import java.util.List;
 public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     private EntryPointType type;
     private String name;
+    private String pathGraphql = "/graphql";
     private Server server = Server.UNDERTOW;
     private BooleanOption router = BooleanOption.TRUE;
 
@@ -42,6 +43,11 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
         this.router = router;
     }
 
+    @Option(option = "pathgql", description = "set API GraphQL path")
+    public void setPathGraphql(String pathgql) {
+        this.pathGraphql = pathgql;
+    }
+
 
     @OptionValues("server")
     public List<Server> getServerOptions() {
@@ -58,6 +64,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
         return Arrays.asList(BooleanOption.values());
     }
 
+
     @TaskAction
     public void generateEntryPointTask() throws IOException, CleanException {
         if (type == null) {
@@ -70,6 +77,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
         logger.lifecycle("Entry Point type: {}", type);
         builder.addParam("task-param-name", name);
         builder.addParam("task-param-server", server);
+        builder.addParam("task-param-pathgql", pathGraphql);
         builder.addParam("task-param-router", router == BooleanOption.TRUE);
         builder.addParam("lombok", builder.isEnableLombok());
         moduleFactory.buildModule(builder);

--- a/src/main/resources/entry-point/graphql-api/api-mutations.java.mustache
+++ b/src/main/resources/entry-point/graphql-api/api-mutations.java.mustache
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 {{/lombok}}
 @Controller
+/**
+* To interact with the API make use of Playground in the "/playground" path, but remember,
+* Playground ONLY must be used in dev or qa environments, not in production.
+*/
 public class ApiMutations implements GraphQLMutationResolver {
 
 //  private final MyUseCase useCase;

--- a/src/main/resources/entry-point/graphql-api/api-mutations.java.mustache
+++ b/src/main/resources/entry-point/graphql-api/api-mutations.java.mustache
@@ -1,0 +1,27 @@
+package {{package}}.graphqlapi;
+
+import graphql.kickstart.tools.GraphQLMutationResolver;
+{{#lombok}}
+import lombok.RequiredArgsConstructor;
+{{/lombok}}
+import org.springframework.stereotype.Controller;
+
+{{#lombok}}
+@RequiredArgsConstructor
+{{/lombok}}
+@Controller
+public class ApiMutations implements GraphQLMutationResolver {
+
+//  private final MyUseCase useCase;
+
+{{^lombok}}
+    public ApiMutations(MyUseCase useCase){
+        this.useCase = useCase;
+    }
+{{/lombok}}
+
+    public String addSomething(String objRequest/* change for object request */) {
+//      return useCase.doAction(objRequest);
+        return "Hello world from graphql-api mutations " + objRequest;
+    }
+}

--- a/src/main/resources/entry-point/graphql-api/api-queries.java.mustache
+++ b/src/main/resources/entry-point/graphql-api/api-queries.java.mustache
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Controller;
     @RequiredArgsConstructor
 {{/lombok}}
 @Controller
+/**
+* To interact with the API make use of Playground in the "/playground" path, but remember,
+* Playground ONLY must be used in dev or qa environments, not in production.
+*/
 public class ApiQueries implements GraphQLQueryResolver {
 
 //  private final MyUseCase useCase;

--- a/src/main/resources/entry-point/graphql-api/api-queries.java.mustache
+++ b/src/main/resources/entry-point/graphql-api/api-queries.java.mustache
@@ -1,0 +1,27 @@
+package {{package}}.graphqlapi;
+
+import graphql.kickstart.tools.GraphQLQueryResolver;
+{{#lombok}}
+import lombok.RequiredArgsConstructor;
+{{/lombok}}
+import org.springframework.stereotype.Controller;
+
+{{#lombok}}
+    @RequiredArgsConstructor
+{{/lombok}}
+@Controller
+public class ApiQueries implements GraphQLQueryResolver {
+
+//  private final MyUseCase useCase;
+
+{{^lombok}}
+    public ApiQueries(MyUseCase useCase){
+    this.useCase = useCase;
+    }
+{{/lombok}}
+
+    public String getSomething(String objRequest/* change for object request */) {
+//      return useCase.doAction(objRequest);
+        return "Hello world from graphql-api queries " + objRequest;
+    }
+}

--- a/src/main/resources/entry-point/graphql-api/build.gradle.mustache
+++ b/src/main/resources/entry-point/graphql-api/build.gradle.mustache
@@ -1,0 +1,7 @@
+dependencies {
+    compile project(':model')
+    compile project(':usecase')
+    compile 'org.springframework:spring-context'
+    compile 'com.graphql-java-kickstart:graphql-spring-boot-starter:11.0.0'
+    compile 'com.graphql-java-kickstart:playground-spring-boot-starter:11.0.0'
+}

--- a/src/main/resources/entry-point/graphql-api/config/api-schema.graphqls.mustache
+++ b/src/main/resources/entry-point/graphql-api/config/api-schema.graphqls.mustache
@@ -1,0 +1,9 @@
+type Query {
+    getSomething(id: String!): String
+}
+
+type Mutation {
+    addSomething(objectRequest: String!): String
+}
+
+

--- a/src/main/resources/entry-point/graphql-api/definition.json
+++ b/src/main/resources/entry-point/graphql-api/definition.json
@@ -1,0 +1,13 @@
+{
+  "folders": [
+    "infrastructure/entry-points/graphql-api/src/main/java/{{packagePath}}/graphql-controllers",
+    "infrastructure/entry-points/graphql-api/src/test/java/{{packagePath}}/graphql-controllers",
+    "applications/app-service/src/main/resources/graphql"
+  ],
+  "files": {
+    "entry-point/graphql-api/config/api-schema.graphqls.mustache": "applications/app-service/src/main/resources/graphql/api-schema.graphqls",
+    "entry-point/graphql-api/api-queries.java.mustache": "infrastructure/entry-points/graphql-api/src/main/java/{{packagePath}}/graphqlapi/ApiQueries.java",
+    "entry-point/graphql-api/api-mutations.java.mustache": "infrastructure/entry-points/graphql-api/src/main/java/{{packagePath}}/graphqlapi/ApiMutations.java",
+    "entry-point/graphql-api/build.gradle.mustache": "infrastructure/entry-points/graphql-api/build.gradle"
+  }
+}

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -125,6 +125,19 @@ public class GenerateEntryPointTaskTest {
     }
 
     @Test
+    public void generateEntryPointApiGraphql() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.GRAPHQL);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/graphql-api/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiQueries.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiMutations.java").exists());
+    }
+
+    @Test
     public void generateEntryPointApiRestWithDefaultServer() throws IOException, CleanException {
         // Arrange
         task.setType(ModuleFactoryEntryPoint.EntryPointType.RESTMVC);


### PR DESCRIPTION
## Description

New feature: users can create an entry point of type Graphql, this makes use of the dependency com.graphql-java-kickstart: graphql-spring-boot-starter, allows the creation and collection of data through mutations and queries .

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the build.gradle, readme.md and gradle.properties was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
