### PR TITLE
org.springframework.boot plugin removed

### DIFF
--- a/src/main/resources/structure/root/build.gradle.mustache
+++ b/src/main/resources/structure/root/build.gradle.mustache
@@ -9,6 +9,9 @@ buildscript {
 		{{#cobertura}}
 		coberturaVersion = '{{coberturaVersion}}'
 		{{/cobertura}}
+		{{#lombok}}
+        lombokVersion = '{{lombokVersion}}'
+        {{/lombok}}
 	}
 }
 

--- a/src/main/resources/structure/root/main.gradle.mustache
+++ b/src/main/resources/structure/root/main.gradle.mustache
@@ -15,7 +15,6 @@ subprojects {
     apply plugin: 'net.saliman.cobertura'
     {{/cobertura}}
     apply plugin: 'io.spring.dependency-management'
-    apply plugin: 'org.springframework.boot'
 
     sourceCompatibility = JavaVersion.VERSION_1_8
 
@@ -28,11 +27,12 @@ subprojects {
         {{/reactive}}
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         {{#lombok}}
-        compileOnly 'org.projectlombok:lombok'
-        annotationProcessor 'org.projectlombok:lombok'
-        testAnnotationProcessor 'org.projectlombok:lombok'
-        testCompileOnly 'org.projectlombok:lombok'
+        compileOnly "org.projectlombok:lombok:${lombokVersion}"
+        annotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
+        testCompileOnly  "org.projectlombok:lombok:${lombokVersion}"
+        testAnnotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
         {{/lombok}}
+        implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
     }
 
     {{#jacoco}}


### PR DESCRIPTION
## Description
org.springframework.boot plugin removed from main gradle.

## Category
- [ ] Feature
- [X] Fix

## Checklist
- [X] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [X] Automated tests are written
- [X] The documentation is up-to-date
- [X] the version of the build.gradle, readme.md and gradle.properties was increased
- [X] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
