### PR TITLE
Fix mongo client factory for reactive projects

### DIFF
--- a/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
@@ -6,7 +6,10 @@ import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
 import org.springframework.beans.factory.annotation.Value;
 {{/include-secret}}
 import {{package}}.mongo.config.MongoDBSecret;
-import org.springframework.boot.autoconfigure.mongo.*;
+import org.springframework.boot.autoconfigure.mongo.ReactiveMongoClientFactory;
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.autoconfigure.mongo.MongoPropertiesClientSettingsBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;

--- a/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
@@ -28,7 +28,7 @@ public class MongoConfig {
     @Bean
     public MongoDBSecret dbSecret(Environment env) {
         return MongoDBSecret.builder()
-                .uri(env.getProperty("spring.data.mongo.uri"))
+                .uri(env.getProperty("spring.data.mongodb.uri"))
                 .build();
     }
     {{/include-secret}}

--- a/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-reactive/config/mongo-config.java.mustache
@@ -6,11 +6,13 @@ import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
 import org.springframework.beans.factory.annotation.Value;
 {{/include-secret}}
 import {{package}}.mongo.config.MongoDBSecret;
-import org.springframework.boot.autoconfigure.mongo.MongoClientFactory;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.autoconfigure.mongo.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 public class MongoConfig {
@@ -32,9 +34,12 @@ public class MongoConfig {
     {{/include-secret}}
 
     @Bean
-    public MongoClientFactory mongoProperties(MongoDBSecret secret, Environment env) {
+    public ReactiveMongoClientFactory mongoProperties(MongoDBSecret secret, Environment env) {
         MongoProperties properties = new MongoProperties();
         properties.setUri(secret.getUri());
-        return new MongoClientFactory(properties, env);
+
+        List<MongoClientSettingsBuilderCustomizer> list = new ArrayList<>();
+        list.add(new MongoPropertiesClientSettingsBuilderCustomizer(properties, env));
+        return new ReactiveMongoClientFactory(list);
     }
 }

--- a/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
@@ -6,7 +6,10 @@ import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
 import org.springframework.beans.factory.annotation.Value;
 {{/include-secret}}
 import {{package}}.mongo.config.MongoDBSecret;
-import org.springframework.boot.autoconfigure.mongo.*;
+import org.springframework.boot.autoconfigure.mongo.MongoClientFactory;
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.autoconfigure.mongo.MongoPropertiesClientSettingsBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;

--- a/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
@@ -6,11 +6,13 @@ import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
 import org.springframework.beans.factory.annotation.Value;
 {{/include-secret}}
 import {{package}}.mongo.config.MongoDBSecret;
-import org.springframework.boot.autoconfigure.mongo.MongoClientFactory;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.autoconfigure.mongo.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 public class MongoConfig {
@@ -35,6 +37,9 @@ public class MongoConfig {
     public MongoClientFactory mongoProperties(MongoDBSecret secret, Environment env) {
         MongoProperties properties = new MongoProperties();
         properties.setUri(secret.getUri());
-        return new MongoClientFactory(properties, env);
+
+        List<MongoClientSettingsBuilderCustomizer> list = new ArrayList<>();
+        list.add(new MongoPropertiesClientSettingsBuilderCustomizer(properties, env));
+        return new MongoClientFactory(list);
     }
 }

--- a/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
+++ b/src/main/resources/driven-adapter/mongo-repository/config/mongo-config.java.mustache
@@ -28,7 +28,7 @@ public class MongoConfig {
     @Bean
     public MongoDBSecret dbSecret(Environment env) {
         return MongoDBSecret.builder()
-                .uri(env.getProperty("spring.data.mongo.uri"))
+                .uri(env.getProperty("spring.data.mongodb.uri"))
                 .build();
     }
     {{/include-secret}}


### PR DESCRIPTION
## Description
Update mongo client factory, remove deprecated instantiation of MongoClientFactory.
Use the correct ReactiveMongoClientFactory for reactive projects.

## Category
- [ ] Feature
- [X] Fix

## Checklist
- [X] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [X] The documentation is up-to-date
- [X] the version of the build.gradle, readme.md and gradle.properties was increased
- [X] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
