### PR TITLE
Feature: new entry point for events, commands and async queries handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.7"
+    id "co.com.bancolombia.cleanArchitecture" version "1.8.8"
 }
 ```
 
@@ -177,18 +177,18 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    gradle gda --type [drivenAdapterType]
    ```
 
-   | Reference for **drivenAdapterType** | Name                 | Additional Options                                 |
-   | ----------------------------------- | -------------------- | -------------------------------------------------- |
-   | generic                             | Empty Driven Adapter | --name [name]                                      |
-   | jpa                                 | JPA Repository       | --secret [true-false]                              |
-   | mongodb                             | Mongo Repository     | --secret [true-false]                              |
-   | asynceventbus                       | Async Event Bus      |                                                    |
-   | restconsumer                        | Rest Client Consumer | --url [url]                                        |
-   | redis                               | Redis                | --mode [template-repository] --secret [true-false] |
-   | rsocket                             | Rsocket Requester    |                                                    |
-   | r2dbc                               | R2dbc Postgresql Client |                                                 |
-   | kms                               | AWS Key Management Service  |                                                 |
-   | secrets                               | Secrets Manager Bancolombia  |                                                 |
+   | Reference for **drivenAdapterType** | Name                        | Additional Options                                 |
+   |-------------------------------------|-----------------------------|----------------------------------------------------|
+   | generic                             | Empty Driven Adapter        | --name [name]                                      |
+   | jpa                                 | JPA Repository              | --secret [true-false]                              |
+   | mongodb                             | Mongo Repository            | --secret [true-false]                              |
+   | asynceventbus                       | Async Event Bus             |                                                    |
+   | restconsumer                        | Rest Client Consumer        | --url [url]                                        |
+   | redis                               | Redis                       | --mode [template-repository] --secret [true-false] |
+   | rsocket                             | Rsocket Requester           |                                                    |
+   | r2dbc                               | R2dbc Postgresql Client     |                                                    |
+   | kms                                 | AWS Key Management Service  |                                                    |
+   | secrets                             | Secrets Manager Bancolombia |                                                    |
 
    _**This task will generate something like that:**_
 
@@ -225,13 +225,14 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    gradle gep --type [entryPointType]
    ```
 
-   | Reference for **entryPointType** | Name                                   | Additional Options         |
-   | -------------------------------- | -------------------------------------- | -------------------------- |
-   | generic                          | Empty Entry Point                      | --name [name]              |
-   | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow    |
+   | Reference for **entryPointType** | Name                                   | Additional Options                       |
+   |----------------------------------|----------------------------------------|------------------------------------------|
+   | generic                          | Empty Entry Point                      | --name [name]                            |
+   | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow |
    | webflux                          | API REST (Spring Boot Starter WebFlux) | --router [true, false] default true      |
-   | rsocket                          | Rsocket Controller Entry Point         |                            |
-   | graphql                          | API GraphQL    | --pathgql [name path] default /graphql                      |
+   | rsocket                          | Rsocket Controller Entry Point         |                                          |
+   | graphql                          | API GraphQL                            | --pathgql [name path] default /graphql   |
+   | asynceventhandler                | Async Event Handler                    |                                          |
 
    Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
 
@@ -241,7 +242,7 @@ The Scaffolding Clean Architecture plugin will allow you run 8 tasks:
    ```
 
    | Reference for **serverOption** | Name                      |
-      | ------------------------------ | ------------------------- |
+   | ------------------------------ | ------------------------- |
    | undertow                       | Undertow server (default) |
    | tomcat                         | Tomcat server             |
    | jetty                          | Jetty server              |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.7
+systemProp.version=1.8.8

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -16,7 +16,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.junit.Assert.*;
@@ -413,14 +415,34 @@ public class PluginCleanFunctionalTest {
         BuildResult result = runner.build();
 
         assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/async-event-bus/build.gradle").exists());
-        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/event/ReactiveEventsGateway.java").exists());
-        assertTrue(new File("build/functionalTest/domain/model/src/main/java/co/com/bancolombia/model/event/gateways/EventsGateway.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveEventsGateway.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveDirectAsyncGateway.java").exists());
+        assertTrue(new File("build/functionalTest/domain/model/src/main/java/co/com/bancolombia/model/events/gateways/EventsGateway.java").exists());
 
         assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
-    public void canRunTaskGenerateDrivenAdapterR2dbcPostgreSQLTest(){
+    public void canRunTaskGenerateEntryPointEventHandlerTest() {
+        canRunTaskGenerateStructureWithOutParameters();
+        String task = "generateEntryPoint";
+        String valueDrivenAdapter = "ASYNCEVENTHANDLER";
+
+        runner.withArguments(task, "--type=" + valueDrivenAdapter);
+        runner.withProjectDir(projectDir);
+        BuildResult result = runner.build();
+
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/async-event-handler/build.gradle").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/HandlerRegistryConfiguration.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/EventsHandler.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/CommandsHandler.java").exists());
+        assertTrue(new File("build/functionalTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/QueriesHandler.java").exists());
+
+        assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void canRunTaskGenerateDrivenAdapterR2dbcPostgreSQLTest() {
         canRunTaskGenerateStructureReactiveProject();
 
         String task = "generateDrivenAdapter";
@@ -437,7 +459,7 @@ public class PluginCleanFunctionalTest {
     }
 
     @Test
-    public void canRunTaskGenerateDrivenAdapterKmsTest(){
+    public void canRunTaskGenerateDrivenAdapterKmsTest() {
         canRunTaskGenerateStructureReactiveProject();
 
         String task = "generateDrivenAdapter";
@@ -556,7 +578,7 @@ public class PluginCleanFunctionalTest {
     @Test(expected = Exception.class)
     public void validateStructureReactiveWithInvalidModel() throws IOException {
         canRunTaskGenerateStructureReactiveProject();
-        writeString(new File("build/functionalTest/domain/model/build.gradle"),"compile 'org.springframework.boot:spring-boot-starter'");
+        writeString(new File("build/functionalTest/domain/model/build.gradle"), "compile 'org.springframework.boot:spring-boot-starter'");
 
         // Act
         runner.withArguments("validateStructure");
@@ -567,7 +589,7 @@ public class PluginCleanFunctionalTest {
     @Test(expected = Exception.class)
     public void validateStructureReactiveWithInvalidUseCase() throws IOException {
         canRunTaskGenerateStructureReactiveProject();
-        writeString(new File("build/functionalTest/domain/usecase/build.gradle"),"compile 'org.springframework.boot:spring-boot-starter'");
+        writeString(new File("build/functionalTest/domain/usecase/build.gradle"), "compile 'org.springframework.boot:spring-boot-starter'");
 
         // Act
         runner.withArguments("validateStructure");

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -14,9 +14,9 @@ public class Constants {
     public static final String JACOCO_VERSION = "0.8.5";
     public static final String COBERTURA_VERSION = "3.0.0";
     public static final String SECRETS_VERSION = "3.0.0";
-    public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "0.4.7";
+    public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "1.0.0-beta5";
     public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-    public static final String PLUGIN_VERSION = "1.8.7";
+    public static final String PLUGIN_VERSION = "1.8.8";
     public static final String TOMCAT_EXCLUSION = "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
 
     public enum BooleanOption {

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointAsyncEventHandler.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointAsyncEventHandler.java
@@ -1,0 +1,17 @@
+package co.com.bancolombia.factory.entrypoints;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+
+import java.io.IOException;
+
+public class EntryPointAsyncEventHandler implements ModuleFactory {
+    @Override
+    public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+        builder.loadPackage();
+        builder.setupFromTemplate("entry-point/async-event-handler");
+        builder.appendToSettings("async-event-handler", "infrastructure/entry-points");
+        builder.appendDependencyToModule("app-service", "implementation project(':async-event-handler')");
+    }
+}

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/ModuleFactoryEntryPoint.java
@@ -17,12 +17,14 @@ public class ModuleFactoryEntryPoint {
                 return new EntryPointRsocketResponder();
             case GRAPHQL:
                 return new EntryPointGraphql();
+            case ASYNCEVENTHANDLER:
+                return new EntryPointAsyncEventHandler();
             default:
                 throw new InvalidTaskOptionException("Entry Point type invalid");
         }
     }
 
     public enum EntryPointType {
-        RESTMVC, WEBFLUX, GENERIC, RSOCKET, GRAPHQL
+        RESTMVC, WEBFLUX, GENERIC, RSOCKET, GRAPHQL, ASYNCEVENTHANDLER
     }
 }

--- a/src/main/resources/driven-adapter/async-event-bus/definition.json
+++ b/src/main/resources/driven-adapter/async-event-bus/definition.json
@@ -1,10 +1,11 @@
 {
   "folders": [
-    "infrastructure/driven-adapters/async-event-bus/src/test/java/{{packagePath}}/event"
+    "infrastructure/driven-adapters/async-event-bus/src/test/java/{{packagePath}}/events"
   ],
   "files": {
-    "driven-adapter/async-event-bus/events-gateway.java.mustache": "domain/model/src/main/java/{{packagePath}}/model/event/gateways/EventsGateway.java",
-    "driven-adapter/async-event-bus/reactive-events-gateway.java.mustache": "infrastructure/driven-adapters/async-event-bus/src/main/java/{{packagePath}}/event/ReactiveEventsGateway.java",
+    "driven-adapter/async-event-bus/events-gateway.java.mustache": "domain/model/src/main/java/{{packagePath}}/model/events/gateways/EventsGateway.java",
+    "driven-adapter/async-event-bus/reactive-events-gateway.java.mustache": "infrastructure/driven-adapters/async-event-bus/src/main/java/{{packagePath}}/events/ReactiveEventsGateway.java",
+    "driven-adapter/async-event-bus/reactive-direct-async-gateway.java.mustache": "infrastructure/driven-adapters/async-event-bus/src/main/java/{{packagePath}}/events/ReactiveDirectAsyncGateway.java",
     "driven-adapter/async-event-bus/build.gradle.mustache": "infrastructure/driven-adapters/async-event-bus/build.gradle"
   }
 }

--- a/src/main/resources/driven-adapter/async-event-bus/events-gateway.java.mustache
+++ b/src/main/resources/driven-adapter/async-event-bus/events-gateway.java.mustache
@@ -1,11 +1,7 @@
-package {{package}}.model.event.gateways;
+package {{package}}.model.events.gateways;
 
 import reactor.core.publisher.Mono;
 
-/**
- * Interfaz propia del dominio para emitir eventos completamente definidos por las necesidades del dominio
- * El tipo Event se puede enriquecer en la medida que sea necesario.
- */
 public interface EventsGateway {
     Mono<Void> emit(Object event);
 }

--- a/src/main/resources/driven-adapter/async-event-bus/reactive-direct-async-gateway.java.mustache
+++ b/src/main/resources/driven-adapter/async-event-bus/reactive-direct-async-gateway.java.mustache
@@ -1,0 +1,49 @@
+package {{package}}.events;
+
+{{#lombok}}
+import lombok.AllArgsConstructor;
+import lombok.extern.java.Log;
+{{/lombok}}
+import org.reactivecommons.api.domain.Command;
+import org.reactivecommons.async.api.AsyncQuery;
+import org.reactivecommons.async.api.DirectAsyncGateway;
+import org.reactivecommons.async.impl.config.annotations.EnableDirectAsyncGateway;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+{{#lombok}}
+import java.util.logging.Level;
+{{/lombok}}
+
+{{#lombok}}
+@Log
+@AllArgsConstructor
+{{/lombok}}
+@EnableDirectAsyncGateway
+public class ReactiveDirectAsyncGateway /*implements SomeGatewayFromDomain*/ {
+    public static final String TARGET_NAME = "cleanArchitecture";// refers to remote spring.application.name property
+    public static final String SOME_COMMAND_NAME = "some.command.name";
+    public static final String SOME_QUERY_NAME = "some.query.name";
+    private final DirectAsyncGateway gateway;
+
+    {{^lombok}}
+    public ReactiveDirectAsyncGateway(DirectAsyncGateway gateway) {
+        this.gateway = gateway;
+    }
+    {{/lombok}}
+
+    public Mono<Void> runRemoteJob(Object command/*change for proper model*/) {
+        {{#lombok}}
+        log.log(Level.INFO, "Sending command: {0}: {1}", new String[]{SOME_COMMAND_NAME, command.toString()});
+        {{/lombok}}
+        return gateway.sendCommand(new Command<>(SOME_COMMAND_NAME, UUID.randomUUID().toString(), command),
+                TARGET_NAME);
+    }
+
+    public Mono<Object> requestForRemoteData(Object query/*change for proper model*/) {
+        {{#lombok}}
+        log.log(Level.INFO, "Sending query request: {0}: {1}", new String[]{SOME_QUERY_NAME, query.toString()});
+        {{/lombok}}
+        return gateway.requestReply(new AsyncQuery<>(SOME_QUERY_NAME, query), TARGET_NAME, Object.class/*change for proper model*/);
+    }
+}

--- a/src/main/resources/driven-adapter/async-event-bus/reactive-events-gateway.java.mustache
+++ b/src/main/resources/driven-adapter/async-event-bus/reactive-events-gateway.java.mustache
@@ -1,6 +1,6 @@
-package {{package}}.event;
+package {{package}}.events;
 
-import {{package}}.model.event.gateways.EventsGateway;
+import {{package}}.model.events.gateways.EventsGateway;
 {{#lombok}}
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
@@ -8,38 +8,35 @@ import lombok.extern.java.Log;
 import org.reactivecommons.api.domain.DomainEvent;
 import org.reactivecommons.api.domain.DomainEventBus;
 import org.reactivecommons.async.impl.config.annotations.EnableDomainEventBus;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.util.UUID;
+{{#lombok}}
 import java.util.logging.Level;
+{{/lombok}}
 
 import static reactor.core.publisher.Mono.from;
 
-@Component
-@EnableDomainEventBus
 {{#lombok}}
 @Log
 @RequiredArgsConstructor
 {{/lombok}}
-/**Permite personalizar la emisión de eventos, enriquecerla o interceptarla.
- Por defecto delega el proceso en reactive-commons.
-
- Remplazar el tipo del objeto  event por le modelo correspondiente
- **/
+@EnableDomainEventBus
 public class ReactiveEventsGateway implements EventsGateway {
-
+    public static final String SOME_EVENT_NAME = "some.event.name";
     private final DomainEventBus domainEventBus;
 
     {{^lombok}}
     public ReactiveEventsGateway(DomainEventBus domainEventBus) {
-    this.domainEventBus = domainEventBus;
+        this.domainEventBus = domainEventBus;
     }
     {{/lombok}}
 
     @Override
     public Mono<Void> emit(Object event) {
-        log.log(Level.INFO, "Emitiendo evento de dominio: {0}: {1}", new String[]{(String) event, event.toString()});
-        return from(domainEventBus.emit(new DomainEvent<>((String) event, UUID.randomUUID().toString(), event)));
+        {{#lombok}}
+        log.log(Level.INFO, "Sending domain event: {0}: {1}", new String[]{SOME_EVENT_NAME, event.toString()});
+        {{/lombok}}
+        return from(domainEventBus.emit(new DomainEvent<>(SOME_EVENT_NAME, UUID.randomUUID().toString(), event)));
     }
 }

--- a/src/main/resources/entry-point/async-event-handler/build.gradle.mustache
+++ b/src/main/resources/entry-point/async-event-handler/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    compile project(':model')
+    compile project(':usecase')
+    compile 'org.reactivecommons:async-commons-starter:{{asyncCommonsStarterVersion}}'
+    compile 'org.springframework:spring-context'
+}

--- a/src/main/resources/entry-point/async-event-handler/commands-handler.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/commands-handler.java.mustache
@@ -1,0 +1,28 @@
+package {{package}}.events.handlers;
+
+{{#lombok}}
+import lombok.AllArgsConstructor;
+{{/lombok}}
+import org.reactivecommons.api.domain.Command;
+import org.reactivecommons.async.impl.config.annotations.EnableCommandListeners;
+import reactor.core.publisher.Mono;
+
+{{#lombok}}
+@AllArgsConstructor
+{{/lombok}}
+@EnableCommandListeners
+public class CommandsHandler {
+//    private final SampleUseCase sampleUseCase;
+
+{{^lombok}}
+    public CommandsHandler(/*SampleUseCase sampleUseCase*/) {
+        //this.sampleUseCase = sampleUseCase;
+    }
+{{/lombok}}
+
+    public Mono<Void> handleCommandA(Command<Object/*change for proper model*/> command) {
+        System.out.println("command received: " + command.getName() + " ->" + command.getData()); // TODO: Remove this line
+//        return sampleUseCase.doSomething(command.getData());
+        return Mono.empty();
+    }
+}

--- a/src/main/resources/entry-point/async-event-handler/definition.json
+++ b/src/main/resources/entry-point/async-event-handler/definition.json
@@ -1,0 +1,12 @@
+{
+  "folders": [
+    "infrastructure/entry-points/async-event-handler/src/test/java/{{packagePath}}/events/handlers"
+  ],
+  "files": {
+    "entry-point/async-event-handler/handler-registry-configuration.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/HandlerRegistryConfiguration.java",
+    "entry-point/async-event-handler/events-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/EventsHandler.java",
+    "entry-point/async-event-handler/commands-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/CommandsHandler.java",
+    "entry-point/async-event-handler/queries-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/QueriesHandler.java",
+    "entry-point/async-event-handler/build.gradle.mustache": "infrastructure/entry-points/async-event-handler/build.gradle"
+  }
+}

--- a/src/main/resources/entry-point/async-event-handler/events-handler.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/events-handler.java.mustache
@@ -1,0 +1,28 @@
+package {{package}}.events.handlers;
+
+{{#lombok}}
+import lombok.AllArgsConstructor;
+{{/lombok}}
+import org.reactivecommons.api.domain.DomainEvent;
+import org.reactivecommons.async.impl.config.annotations.EnableEventListeners;
+import reactor.core.publisher.Mono;
+
+{{#lombok}}
+@AllArgsConstructor
+{{/lombok}}
+@EnableEventListeners
+public class EventsHandler {
+//    private final SampleUseCase sampleUseCase;
+
+{{^lombok}}
+    public EventsHandler(/*SampleUseCase sampleUseCase*/) {
+        //this.sampleUseCase = sampleUseCase;
+    }
+{{/lombok}}
+
+    public Mono<Void> handleEventA(DomainEvent<Object/*change for proper model*/> event) {
+        System.out.println("event received: " + event.getName() + " ->" + event.getData()); // TODO: Remove this line
+//        return sampleUseCase.doSomething(event.getData());
+        return Mono.empty();
+    }
+}

--- a/src/main/resources/entry-point/async-event-handler/handler-registry-configuration.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/handler-registry-configuration.java.mustache
@@ -1,0 +1,22 @@
+package {{package}}.events;
+
+import {{package}}.events.handlers.CommandsHandler;
+import {{package}}.events.handlers.EventsHandler;
+import {{package}}.events.handlers.QueriesHandler;
+import org.reactivecommons.async.api.HandlerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HandlerRegistryConfiguration {
+
+    // see more at: https://reactivecommons.org/reactive-commons-java/#_handlerregistry_2
+    @Bean
+    public HandlerRegistry handlerRegistry(CommandsHandler commands, EventsHandler events, QueriesHandler queries) {
+        return HandlerRegistry.register()
+                .listenNotificationEvent("some.broadcast.event.name", events::handleEventA, Object.class/*change for proper model*/)
+                .listenEvent("some.event.name", events::handleEventA, Object.class/*change for proper model*/)
+                .handleCommand("some.command.name", commands::handleCommandA, Object.class/*change for proper model*/)
+                .serveQuery("some.query.name", queries::handleQueryA, Object.class/*change for proper model*/);
+    }
+}

--- a/src/main/resources/entry-point/async-event-handler/queries-handler.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/queries-handler.java.mustache
@@ -1,0 +1,27 @@
+package {{package}}.events.handlers;
+
+{{#lombok}}
+import lombok.AllArgsConstructor;
+{{/lombok}}
+import org.reactivecommons.async.impl.config.annotations.EnableQueryListeners;
+import reactor.core.publisher.Mono;
+
+{{#lombok}}
+@AllArgsConstructor
+{{/lombok}}
+@EnableQueryListeners
+public class QueriesHandler {
+//    private final SampleUseCase sampleUseCase;
+
+{{^lombok}}
+    public QueriesHandler(/*SampleUseCase sampleUseCase*/) {
+        //this.sampleUseCase = sampleUseCase;
+    }
+{{/lombok}}
+
+    public Mono<Object/*change for proper model*/> handleQueryA(Object query/*change for proper model*/) {
+        System.out.println("query received->" + query); // TODO: Remove this line
+//        return sampleUseCase.doSomethingReturningNoMonoVoid(query);
+        return Mono.just("Response Data");
+    }
+}

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -217,8 +217,9 @@ public class GenerateDrivenAdapterTaskTest {
         task.generateDrivenAdapterTask();
         // Assert
         assertTrue(new File("build/unitTest/infrastructure/driven-adapters/async-event-bus/build.gradle").exists());
-        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/event/ReactiveEventsGateway.java").exists());
-        assertTrue(new File("build/unitTest/domain/model/src/main/java/co/com/bancolombia/model/event/gateways/EventsGateway.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveEventsGateway.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveDirectAsyncGateway.java").exists());
+        assertTrue(new File("build/unitTest/domain/model/src/main/java/co/com/bancolombia/model/events/gateways/EventsGateway.java").exists());
     }
 
     @Test

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -4,9 +4,9 @@ import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.entrypoints.EntryPointRestMvcServer;
 import co.com.bancolombia.factory.entrypoints.ModuleFactoryEntryPoint;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.file.SimplePathVisitor;
 import org.gradle.api.Project;
-import org.apache.commons.io.FileUtils;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -243,6 +243,21 @@ public class GenerateEntryPointTaskTest {
         assertTrue(new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
         assertTrue(new File("build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Router.java").exists());
         assertTrue(new File("build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java").exists());
+    }
+
+    @Test
+    public void generateEntryPointAsyncEventHandler() throws IOException, CleanException {
+        // Arrange
+        setup(GenerateStructureTask.ProjectType.REACTIVE);
+        task.setType(ModuleFactoryEntryPoint.EntryPointType.ASYNCEVENTHANDLER);
+        // Act
+        task.generateEntryPointTask();
+        // Assert
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/async-event-handler/build.gradle").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/HandlerRegistryConfiguration.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/EventsHandler.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/CommandsHandler.java").exists());
+        assertTrue(new File("build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/QueriesHandler.java").exists());
     }
 
 


### PR DESCRIPTION
## Description
Implements new Entry Point `ASYNCEVENTHANDLER` for events, commands and async queries using Reactive Commons abstraction. Resolves #100

Driven Adapter `ASYNCEVENTBUS` updated to be able to send commands and async queries.

## Category
- [X] Feature
- [ ] Fix

## Checklist
- [X] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [X] Automated tests are written
- [X] The documentation is up-to-date
- [X] the version of the build.gradle, readme.md and gradle.properties was increased
- [X] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
