### PR TITLE
feat: messaging patterns conventions

### DIFF
--- a/src/main/resources/entry-point/async-event-handler/command-handlers-configuration.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/command-handlers-configuration.java.mustache
@@ -1,0 +1,65 @@
+package {{package}}.events.convention;
+
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.async.api.DefaultCommandHandler;
+import org.reactivecommons.async.api.HandlerRegistry;
+import org.reactivecommons.async.api.handlers.CommandHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import java.util.Map;
+
+
+@Configuration
+@RequiredArgsConstructor
+@ComponentScan(
+        basePackages = "{{package}}.events.handlers",
+        includeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = CommandHandler.class)
+        })
+public class CommandHandlersConfiguration {
+
+    private static final String COMMAND_EXECUTOR_SUFFIX = CommandHandler.class.getSimpleName();
+    private static final String ILLEGAL_EXECUTOR_SUFFIX =
+            String.format("All command executors must use '%s' suffix", COMMAND_EXECUTOR_SUFFIX);
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public HandlerRegistry commandExecutorsRegistry() {
+        Map<String, CommandHandler> commandHandlers = applicationContext.getBeansOfType(CommandHandler.class);
+        HandlerRegistry handlerRegistry = HandlerRegistry.register();
+
+        commandHandlers.entrySet().stream()
+                .filter(this::isNotDefaultCommandHandler)
+                .forEach(entry ->
+                        handlerRegistry.handleCommand(getCommandName(entry.getKey()),
+                                entry.getValue()));
+
+        return handlerRegistry;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private boolean isNotDefaultCommandHandler(Map.Entry<String, CommandHandler> entry) {
+        return !(entry.getValue() instanceof DefaultCommandHandler);
+    }
+
+    public String getCommandName(String executorName) {
+        if (!executorName.endsWith(COMMAND_EXECUTOR_SUFFIX)) {
+            throw new IllegalArgumentException(ILLEGAL_EXECUTOR_SUFFIX);
+        }
+
+        String commandName = executorName.substring(0, executorName.indexOf(COMMAND_EXECUTOR_SUFFIX));
+
+        return applicationName + "." + commandName;
+    }
+
+}

--- a/src/main/resources/entry-point/async-event-handler/definition.json
+++ b/src/main/resources/entry-point/async-event-handler/definition.json
@@ -7,6 +7,11 @@
     "entry-point/async-event-handler/events-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/EventsHandler.java",
     "entry-point/async-event-handler/commands-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/CommandsHandler.java",
     "entry-point/async-event-handler/queries-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/QueriesHandler.java",
-    "entry-point/async-event-handler/build.gradle.mustache": "infrastructure/entry-points/async-event-handler/build.gradle"
+    "entry-point/async-event-handler/build.gradle.mustache": "infrastructure/entry-points/async-event-handler/build.gradle",
+    "entry-point/async-event-handler/example-query-handler.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/handlers/ExampleConventionQueryHandler.java",
+    "entry-point/async-event-handler/query-handlers-configuration.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/convention/QueryHandlersConfiguration.java",
+    "entry-point/async-event-handler/command-handlers-configuration.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/convention/CommandHandlersConfiguration.java",
+    "entry-point/async-event-handler/event-name.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/convention/EventName.java",
+    "entry-point/async-event-handler/event-handlers-configuration.java.mustache": "infrastructure/entry-points/async-event-handler/src/main/java/{{packagePath}}/events/convention/EventHandlersConfiguration.java"
   }
 }

--- a/src/main/resources/entry-point/async-event-handler/event-handlers-configuration.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/event-handlers-configuration.java.mustache
@@ -1,0 +1,60 @@
+package {{package}}.events.convention;
+
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.async.api.HandlerRegistry;
+import org.reactivecommons.async.api.handlers.EventHandler;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.Map;
+
+
+@Configuration
+@RequiredArgsConstructor
+@ComponentScan(
+        basePackages = "{{package}}.events.handlers",
+        includeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = EventHandler.class)
+        })
+public class EventHandlersConfiguration {
+
+    private static final String EVENT_LISTENER_SUFFIX = EventHandler.class.getSimpleName();
+    private static final String ILLEGAL_LISTENER_SUFFIX =
+            String.format("All event listeners must use '%s' suffix", EVENT_LISTENER_SUFFIX);
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public HandlerRegistry eventListenersRegistry() {
+        Map<String, EventHandler> eventHandlers = applicationContext.getBeansOfType(EventHandler.class);
+        HandlerRegistry handlerRegistry = HandlerRegistry.register();
+
+        eventHandlers.forEach((eventHandlerName, eventHandler) ->
+                handlerRegistry.listenEvent(getEventName(eventHandlerName, eventHandler),
+                        eventHandler));
+
+        return handlerRegistry;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private String getEventName(String eventListenerName, EventHandler eventListener) {
+        if (!eventListenerName.endsWith(EVENT_LISTENER_SUFFIX)) {
+            throw new IllegalArgumentException(ILLEGAL_LISTENER_SUFFIX);
+        }
+
+        EventName annotation = AnnotationUtils.findAnnotation(eventListener.getClass(), EventName.class);
+
+        if (annotation == null) {
+            throw new IllegalArgumentException(eventListenerName + " is not annotated with @" +
+                    EventName.class.getSimpleName());
+        }
+
+        return annotation.value();
+    }
+
+}

--- a/src/main/resources/entry-point/async-event-handler/event-name.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/event-name.java.mustache
@@ -1,0 +1,15 @@
+package {{package}}.events.convention;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EventName {
+
+    String value();
+
+}

--- a/src/main/resources/entry-point/async-event-handler/example-query-handler.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/example-query-handler.java.mustache
@@ -1,0 +1,15 @@
+package {{package}}.events.handlers;
+
+import org.reactivecommons.async.api.handlers.QueryHandler;
+import reactor.core.publisher.Mono;
+
+
+// this registers a query with [appName].exampleConvention
+public class ExampleConventionQueryHandler implements QueryHandler<String, Integer> {
+
+    @Override
+    public Mono<String> handle(Integer message) {
+        return Mono.just("Response for " + message);
+    }
+
+}

--- a/src/main/resources/entry-point/async-event-handler/query-handlers-configuration.java.mustache
+++ b/src/main/resources/entry-point/async-event-handler/query-handlers-configuration.java.mustache
@@ -1,0 +1,65 @@
+package {{package}}.events.convention;
+
+import lombok.RequiredArgsConstructor;
+import org.reactivecommons.async.api.DefaultQueryHandler;
+import org.reactivecommons.async.api.HandlerRegistry;
+import org.reactivecommons.async.api.handlers.QueryHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import java.util.Map;
+
+
+@Configuration
+@RequiredArgsConstructor
+@ComponentScan(
+        basePackages = "{{package}}.events.handlers",
+        includeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = QueryHandler.class)
+        })
+public class QueryHandlersConfiguration {
+
+    private static final String QUERY_HANDLER_SUFFIX = QueryHandler.class.getSimpleName();
+    private static final String ILLEGAL_HANDLER_SUFFIX =
+            String.format("All query handlers must use '%s' suffix", QUERY_HANDLER_SUFFIX);
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public HandlerRegistry queryHandlersRegistry() {
+        Map<String, QueryHandler> queryHandlers = applicationContext.getBeansOfType(QueryHandler.class);
+        HandlerRegistry handlerRegistry = HandlerRegistry.register();
+
+        queryHandlers.entrySet().stream()
+                .filter(this::isNotDefaultQueryHandler)
+                .forEach(entry ->
+                        handlerRegistry.serveQuery(getQueryResource(entry.getKey()),
+                                entry.getValue()));
+
+        return handlerRegistry;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private boolean isNotDefaultQueryHandler(Map.Entry<String, QueryHandler> entry) {
+        return !(entry.getValue() instanceof DefaultQueryHandler);
+    }
+
+    private String getQueryResource(String handlerName) {
+        if (!handlerName.endsWith(QUERY_HANDLER_SUFFIX)) {
+            throw new IllegalArgumentException(ILLEGAL_HANDLER_SUFFIX);
+        }
+
+        String queryName = handlerName.substring(0, handlerName.indexOf(QUERY_HANDLER_SUFFIX));
+
+        return applicationName + "." + queryName;
+    }
+
+}


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
This enables queries, commands and events to be registered based on convention.
Command handlers must extend the interface `CommandHandler` and use `CommandHandler` as suffix for the className, same for queries with `QueryHandler` class and prefix. For events same rules apply with `EventHandler` and additionally you must annotate the class with `@EventName("anotherApp.eventName")`

The registered name for queries and commands are computed using [appName].[classPrefix], for example the class `ExampleConventionQueryHandler` is registered with `cleanArchitecture.exampleConvention`, events are registered with the value passed in `@EventName`.

For example a event handler is registered like this:
```
@EventName("anotherApp.userRegistered")
public class UserRegisteredEventHandler implements EventHandler<String> {
    
    @Override
    public Mono<Void> handle(DomainEvent<String> message) {
        return null;
    }
}
```

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [ ] the version of the readme.md, Constants.java and gradle.properties was increased
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
