### PR TITLE
Sonarqube automatic module and sources settings

### DIFF
--- a/src/main/resources/structure/root/build.gradle.mustache
+++ b/src/main/resources/structure/root/build.gradle.mustache
@@ -28,12 +28,11 @@ plugins {
 }
 
 sonarqube {
+    def modules = subprojects.projectDir.collect { "${it.toString().replace(project.projectDir.toString() + "/", "")}" }
     properties {
         property "sonar.sourceEnconding", "UTF-8"
-        property "sonar.modules", "applications/app-service," +
-                "domain/model, domain/usecase," +
-                "infrastructure/driven-adapters/*, infrastructure/entry-points/*"
-        property "sonar.sources", "src, deployment, build.gradle, applications/app-service/build.gradle"
+        property "sonar.modules", "${modules.join(',')}"
+        property "sonar.sources", "src,deployment,settings.gradle,main.gradle,build.gradle,${modules.collect { "${it}/build.gradle" }.join(',')}"
         property "sonar.test", "src/test"
         property "sonar.java.binaries", "{{sonar.java.binaries}}"
         property "sonar.junit.reportsPath", "{{sonar.junit.reportsPaths}}"
@@ -41,4 +40,5 @@ sonarqube {
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
+
 apply from: './main.gradle'


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Setup modules and *.gradle files automatically from gradle subprojects.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [ ] the version of the readme.md, Constants.java and gradle.properties was increased
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
