### PR TITLE
Change Name Constructor S3Operations Without Lombok

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the plugin you need Gradle version 5.6 or later, to start add the followi
 
 ```groovy
 plugins {
-    id "co.com.bancolombia.cleanArchitecture" version "1.8.9"
+    id "co.com.bancolombia.cleanArchitecture" version "1.9.0"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 package=co.com.bancolombia
-systemProp.version=1.8.9
+systemProp.version=1.9.0

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -16,7 +16,7 @@ public class Constants {
   public static final String COBERTURA_VERSION = "3.0.0";
   public static final String RCOMMONS_ASYNC_COMMONS_STARTER_VERSION = "1.0.0-beta5";
   public static final String RCOMMONS_OBJECT_MAPPER_VERSION = "0.1.0";
-  public static final String PLUGIN_VERSION = "1.8.9";
+  public static final String PLUGIN_VERSION = "1.9.0";
   public static final String TOMCAT_EXCLUSION =
       "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
 

--- a/src/main/resources/driven-adapter/s3-reactive/s3-operations.java.mustache
+++ b/src/main/resources/driven-adapter/s3-reactive/s3-operations.java.mustache
@@ -23,7 +23,7 @@ public class S3Operations {
     private final S3AsyncClient s3AsyncClient;
 
 {{^lombok}}
-    public S3Adapter(S3AsyncClient s3AsyncClient ) {
+    public S3Operations(S3AsyncClient s3AsyncClient ) {
         this.s3AsyncClient = s3AsyncClient;
     }
 {{/lombok}}

--- a/src/main/resources/driven-adapter/s3/s3-operations.java.mustache
+++ b/src/main/resources/driven-adapter/s3/s3-operations.java.mustache
@@ -21,7 +21,7 @@ public class S3Operations {
     private final S3Client s3Client;
 
 {{^lombok}}
-    public S3Adapter(S3Client s3Client ) {
+    public S3Operations(S3Client s3Client ) {
         this.s3Client = s3Client;
     }
 {{/lombok}}


### PR DESCRIPTION
## Description
Change name of S3Operations, according to name Class

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] the version of the readme.md, Constants.java and gradle.properties was increased
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
