### PR TITLE
Upgrade common configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,12 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.spullara.mustache.java:compiler:0.9.6'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.0'
-    compile 'commons-io:commons-io:2.7'
-    compile gradleApi()
-    testCompile "org.mockito:mockito-core:2.9.0"
+    api 'com.github.spullara.mustache.java:compiler:0.9.6'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.0'
+    api 'commons-io:commons-io:2.7'
+    api gradleApi()
+    testImplementation "org.mockito:mockito-core:2.9.0"
     testImplementation 'junit:junit:4.12'
     testImplementation gradleTestKit()
 


### PR DESCRIPTION
In Gradle 7, both the compile and runtime configurations are removed. Therefore, we have to migrate to the implementation and api configurations above.

Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
<!--- Describe your changes in detail -->

## Category
- [ ] Feature
- [ ] Fix

## Checklist
- [ ] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
