### PR TITLE
Update commons jms

### DIFF
--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -917,6 +917,26 @@ public class PluginCleanFunctionalTest {
     assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
   }
 
+  @Test
+  public void shouldGenerateMQDrivenAdapterNoReactive() {
+    canRunTaskGenerateStructureWithOutParameters();
+    String task = "generateDrivenAdapter";
+    String type = "MQ";
+
+    runner.withArguments(task, "--type=" + type);
+    runner.withProjectDir(projectDir);
+    BuildResult result = runner.build();
+
+    assertTrue(
+        new File("build/functionalTest/infrastructure/driven-adapters/mq-sender/build.gradle")
+            .exists());
+    assertTrue(
+        new File(
+                "build/functionalTest/infrastructure/driven-adapters/mq-sender/src/main/java/co/com/bancolombia/mq/sender/SampleMQMessageSender.java")
+            .exists());
+    assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
+  }
+
   private void writeString(File file, String string) throws IOException {
     try (Writer writer = new FileWriter(file)) {
       writer.write(string);

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -20,7 +20,7 @@ public class Constants {
   public static final String GRADLE_WRAPPER_VERSION = "6.7";
   public static final String TOMCAT_EXCLUSION =
       "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
-  public static final String COMMONS_JMS_VERSION = "0.0.1";
+  public static final String COMMONS_JMS_VERSION = "0.0.3";
 
   public enum BooleanOption {
     TRUE,

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMQ.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMQ.java
@@ -3,15 +3,13 @@ package co.com.bancolombia.factory.adapters;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
-import co.com.bancolombia.factory.validations.ReactiveTypeValidation;
 import java.io.IOException;
 
 public class DrivenAdapterMQ implements ModuleFactory {
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
-    builder.runValidations(ReactiveTypeValidation.class);
-    builder.setupFromTemplate("driven-adapter/mq-sender");
+    builder.setupFromTemplate(getTemplate(builder.isReactive()));
     builder.appendToSettings("mq-sender", "infrastructure/driven-adapters");
     builder.appendDependencyToModule("app-service", "implementation project(':mq-sender')");
 
@@ -22,5 +20,9 @@ public class DrivenAdapterMQ implements ModuleFactory {
         .put("producer-ttl", 0)
         .put("reactive", builder.isReactive());
     builder.appendToProperties("ibm.mq").put("channel", "DEV.APP.SVRCONN").put("user", "app");
+  }
+
+  private String getTemplate(boolean reactive) {
+    return reactive ? "driven-adapter/mq-sender" : "driven-adapter/mq-sender-sync";
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointMQ.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointMQ.java
@@ -3,15 +3,13 @@ package co.com.bancolombia.factory.entrypoints;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
-import co.com.bancolombia.factory.validations.ReactiveTypeValidation;
 import java.io.IOException;
 
 public class EntryPointMQ implements ModuleFactory {
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
-    builder.runValidations(ReactiveTypeValidation.class);
-    builder.setupFromTemplate("entry-point/mq-listener");
+    builder.setupFromTemplate(getTemplate(builder.isReactive()));
     builder.appendToSettings("mq-listener", "infrastructure/entry-points");
     builder.appendDependencyToModule("app-service", "implementation project(':mq-listener')");
 
@@ -22,5 +20,9 @@ public class EntryPointMQ implements ModuleFactory {
         .put("input-queue-alias", "")
         .put("reactive", builder.isReactive());
     builder.appendToProperties("ibm.mq").put("channel", "DEV.APP.SVRCONN").put("user", "app");
+  }
+
+  private String getTemplate(boolean reactive) {
+    return reactive ? "entry-point/mq-listener" : "entry-point/mq-listener-sync";
   }
 }

--- a/src/main/resources/driven-adapter/mq-sender-sync/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/mq-sender-sync/build.gradle.mustache
@@ -1,0 +1,5 @@
+dependencies {
+    implementation project(':model')
+    implementation 'com.github.bancolombia:commons-jms-mq:{{commonsJmsVersion}}'
+    implementation 'org.springframework:spring-context'
+}

--- a/src/main/resources/driven-adapter/mq-sender-sync/definition.json
+++ b/src/main/resources/driven-adapter/mq-sender-sync/definition.json
@@ -1,0 +1,9 @@
+{
+  "folders": [
+    "infrastructure/driven-adapters/mq-sender/src/test/java/{{packagePath}}/mq/sender"
+  ],
+  "files": {
+    "driven-adapter/mq-sender-sync/sample-mq-message-sender.java.mustache": "infrastructure/driven-adapters/mq-sender/src/main/java/{{packagePath}}/mq/sender/SampleMQMessageSender.java",
+    "driven-adapter/mq-sender-sync/build.gradle.mustache": "infrastructure/driven-adapters/mq-sender/build.gradle"
+  }
+}

--- a/src/main/resources/driven-adapter/mq-sender-sync/sample-mq-message-sender.java.mustache
+++ b/src/main/resources/driven-adapter/mq-sender-sync/sample-mq-message-sender.java.mustache
@@ -1,6 +1,6 @@
 package {{package}}.mq.sender;
 
-import co.com.bancolombia.commons.jms.api.MQMessageSender;
+import co.com.bancolombia.commons.jms.api.MQMessageSenderSync;
 import co.com.bancolombia.commons.jms.mq.EnableMQMessageSender;
 {{#lombok}}
 import lombok.AllArgsConstructor;
@@ -17,9 +17,9 @@ import javax.jms.Message;
 @EnableMQMessageSender
 //@EnableMQSelectorMessageListener // Enable it to retrieve a specific message by correlationId
 public class SampleMQMessageSender /* implements SomeGateway */ {
-    private final MQMessageSender sender;
+    private final MQMessageSenderSync sender;
 //    private final MQTemporaryQueuesContainer container; // Inject it to reference a temporary queue
-//    private final MQMessageSelectorListener listener; // Inject it to retrieve a specific message by correlationId
+//    private final MQMessageSelectorListenerSync listener; // Inject it to retrieve a specific message by correlationId
     {{^lombok}}
 
     public MyMessageSender(MQMessageSender sender) {
@@ -27,7 +27,7 @@ public class SampleMQMessageSender /* implements SomeGateway */ {
     }
     {{/lombok}}
 
-    public Mono<String> send(String message) {
+    public String send(String message) {
         return sender.send(context -> {
             Message textMessage = context.createTextMessage(message);
 //            textMessage.setJMSReplyTo(container.get("any-custom-value")); // Inject the reply to queue from container
@@ -36,9 +36,9 @@ public class SampleMQMessageSender /* implements SomeGateway */ {
     }
 
     // Enable it to retrieve a specific message by correlationId
-//    public Mono<String> getResult(String correlationId) {
-//        return listener.getMessage(correlationId)
-//                .map(this::extractResponse);
+//    public String getResult(String correlationId) {
+//        Message message = listener.getMessage(correlationId);
+//        return extractResponse(message);
 //    }
 //
 //    private String extractResponse(Message message) {

--- a/src/main/resources/entry-point/mq-listener-sync/build.gradle.mustache
+++ b/src/main/resources/entry-point/mq-listener-sync/build.gradle.mustache
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'com.github.bancolombia:commons-jms-mq:{{commonsJmsVersion}}'
+    implementation 'org.springframework:spring-context'
+}

--- a/src/main/resources/entry-point/mq-listener-sync/definition.json
+++ b/src/main/resources/entry-point/mq-listener-sync/definition.json
@@ -1,0 +1,9 @@
+{
+  "folders": [
+    "infrastructure/entry-points/mq-listener/src/test/java/{{packagePath}}/mq/listener"
+  ],
+  "files": {
+    "entry-point/mq-listener-sync/sample-mq-message-listener.java.mustache": "infrastructure/entry-points/mq-listener/src/main/java/{{packagePath}}/mq/listener/SampleMQMessageListener.java",
+    "entry-point/mq-listener-sync/build.gradle.mustache": "infrastructure/entry-points/mq-listener/build.gradle"
+  }
+}

--- a/src/main/resources/entry-point/mq-listener-sync/sample-mq-message-listener.java.mustache
+++ b/src/main/resources/entry-point/mq-listener-sync/sample-mq-message-listener.java.mustache
@@ -1,0 +1,40 @@
+package {{package}}.mq.listener;
+
+import co.com.bancolombia.commons.jms.mq.MQListener;
+{{#lombok}}
+import lombok.AllArgsConstructor;
+{{/lombok}}
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+@Component
+{{#lombok}}
+@AllArgsConstructor
+{{/lombok}}
+public class SampleMQMessageListener {
+    // private final SampleUseCase useCase;
+
+    {{^lombok}}
+    public SampleMQMessageListener(/*SampleUseCase useCase*/) {
+        // this.useCase = useCase;
+    }
+
+    {{/lombok}}
+    // For fixed queues
+    @MQListener
+    public void process(Message message) throws JMSException {
+        String text = ((TextMessage) message).getText();
+        // useCase.sample(text);
+    }
+
+    // For an automatic generated temporary queue
+    // @MQListener(tempQueueAlias = "any-custom-value")
+    // public void processFromTemporaryQueue(Message message) throws JMSException {
+    //     String text = ((TextMessage) message).getText();
+    //     // useCase.sample(text);
+    // }
+}


### PR DESCRIPTION
## Description
Upgrade MQ entry point and driven adapter to allow usage from non reactive projects, this update allows also the selective message listening by correlation Id.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
