### PR TITLE
Rename router class - Webflux entrypoint

### DIFF
--- a/src/main/resources/entry-point/rest-webflux/router-functions/definition.json
+++ b/src/main/resources/entry-point/rest-webflux/router-functions/definition.json
@@ -3,7 +3,7 @@
     "infrastructure/entry-points/reactive-web/src/test/java/{{packagePath}}/api"
   ],
   "files": {
-    "entry-point/rest-webflux/router-functions/router.java.mustache": "infrastructure/entry-points/reactive-web/src/main/java/{{packagePath}}/api/Router.java",
+    "entry-point/rest-webflux/router-functions/router.java.mustache": "infrastructure/entry-points/reactive-web/src/main/java/{{packagePath}}/api/RouterRest.java",
     "entry-point/rest-webflux/router-functions/handler.java.mustache": "infrastructure/entry-points/reactive-web/src/main/java/{{packagePath}}/api/Handler.java",
     "entry-point/rest-webflux/build.gradle.mustache": "infrastructure/entry-points/reactive-web/build.gradle"
   }

--- a/src/main/resources/entry-point/rest-webflux/router-functions/router.java.mustache
+++ b/src/main/resources/entry-point/rest-webflux/router-functions/router.java.mustache
@@ -10,11 +10,11 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 
 
 @Configuration
-public class Router {
+public class RouterRest {
 @Bean
 public RouterFunction<ServerResponse> routerFunction(Handler handler) {
     return route(GET("/api/usecase/path"), handler::listenGETUseCase)
     .andRoute(POST("/api/usecase/otherpath"), handler::listenPOSTUseCase).and(route(GET("/api/otherusercase/path"), handler::listenGETOtherUseCase));
 
     }
-    }
+}

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -288,7 +288,7 @@ public class GenerateEntryPointTaskTest {
             .exists());
     assertFalse(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Router.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
             .exists());
     assertFalse(
         new File(
@@ -311,7 +311,7 @@ public class GenerateEntryPointTaskTest {
         new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Router.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
             .exists());
     assertTrue(
         new File(
@@ -333,7 +333,7 @@ public class GenerateEntryPointTaskTest {
         new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Router.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
             .exists());
     assertTrue(
         new File(


### PR DESCRIPTION
When use driven adapter async event bus
and entrypoint webflux. the router entrypoint class generate conflict 
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
<!--- Describe your changes in detail -->

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
