### PR TITLE
add swagger to rest entry-points include reactive

### DIFF
--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
@@ -15,6 +15,15 @@ public class EntryPointRestMvc implements ModuleFactory {
     builder.appendToSettings("api-rest", "infrastructure/entry-points");
     String dependency = buildImplementationFromProject(builder.isKotlin(), ":api-rest");
     builder.appendDependencyToModule("app-service", dependency);
+    if (Boolean.TRUE.equals(builder.getBooleanParam("include-swagger"))) {
+      builder.addParam("module", "api-rest");
+      builder.setupFromTemplate("entry-point/swagger");
+      if (builder.isKotlin()) {
+        builder
+            .appendToProperties("spring.mvc.pathmatch")
+            .put("matching-strategy", "ant_path_matcher");
+      }
+    }
     new EntryPointRestMvcServer().buildModule(builder);
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestWebflux.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestWebflux.java
@@ -16,6 +16,15 @@ public class EntryPointRestWebflux implements ModuleFactory {
       builder.setupFromTemplate("entry-point/rest-webflux/router-functions");
     } else {
       builder.setupFromTemplate("entry-point/rest-webflux");
+      if (Boolean.TRUE.equals(builder.getBooleanParam("include-swagger"))) {
+        builder.addParam("module", "reactive-web");
+        builder.setupFromTemplate("entry-point/swagger");
+        if (builder.isKotlin()) {
+          builder
+              .appendToProperties("spring.mvc.pathmatch")
+              .put("matching-strategy", "ant_path_matcher");
+        }
+      }
     }
     builder.appendToSettings("reactive-web", "infrastructure/entry-points");
     String dependency = buildImplementationFromProject(builder.isKotlin(), ":reactive-web");

--- a/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
@@ -20,6 +20,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
   private String pathGraphql = "/graphql";
   private Server server = Server.UNDERTOW;
   private BooleanOption router = BooleanOption.TRUE;
+  private BooleanOption swagger = BooleanOption.FALSE;
 
   @Option(option = "type", description = "Set type of entry point to be generated")
   public void setType(EntryPointType type) {
@@ -43,6 +44,11 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     this.router = router;
   }
 
+  @Option(option = "swagger", description = "Set swagger configuration to rest entry point ")
+  public void setSwagger(BooleanOption swagger) {
+    this.swagger = swagger;
+  }
+
   @Option(option = "pathgql", description = "set API GraphQL path")
   public void setPathGraphql(String pathgql) {
     this.pathGraphql = pathgql;
@@ -63,6 +69,11 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     return Arrays.asList(BooleanOption.values());
   }
 
+  @OptionValues("swagger")
+  public List<BooleanOption> getSwaggerOptions() {
+    return Arrays.asList(BooleanOption.values());
+  }
+
   @TaskAction
   public void generateEntryPointTask() throws IOException, CleanException {
     if (type == null) {
@@ -78,6 +89,7 @@ public class GenerateEntryPointTask extends CleanArchitectureDefaultTask {
     builder.addParam("task-param-server", server);
     builder.addParam("task-param-pathgql", pathGraphql);
     builder.addParam("task-param-router", router == BooleanOption.TRUE);
+    builder.addParam("include-swagger", swagger == BooleanOption.TRUE);
     builder.addParam("lombok", builder.isEnableLombok());
     moduleFactory.buildModule(builder);
     builder.persist();

--- a/src/main/resources/entry-point/rest-mvc/build.gradle.kts.mustache
+++ b/src/main/resources/entry-point/rest-mvc/build.gradle.kts.mustache
@@ -2,5 +2,15 @@ dependencies {
     implementation(project(":usecase"))
     implementation(project(":model"))
     implementation("org.springframework.boot:spring-boot-starter-web")
+{{^include-swagger}}
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+{{/include-swagger}}
+{{#include-swagger}}
+    //don't add "spring-boot-starter-actuator" with spring boot 2.6.x meanwhile bug exist in springfox-swagger2 !!
+    implementation("io.springfox:springfox-swagger-ui:3.0.0")
+    implementation("io.springfox:springfox-swagger2:3.0.0")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
+    implementation("org.springdoc:springdoc-openapi-data-rest:1.6.5")
+    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.5")
+{{/include-swagger}}
 }

--- a/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
+++ b/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
@@ -3,4 +3,8 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+{{#include-swagger}}
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+{{/include-swagger}}
 }

--- a/src/main/resources/entry-point/rest-webflux/build.gradle.kts.mustache
+++ b/src/main/resources/entry-point/rest-webflux/build.gradle.kts.mustache
@@ -2,5 +2,15 @@ dependencies {
     implementation(project(":usecase"))
     implementation(project(":model"))
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+{{^include-swagger}}
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+{{/include-swagger}}
+{{#include-swagger}}
+    //don't add "spring-boot-starter-actuator" with spring boot 2.6.x meanwhile bug exist in springfox-swagger2 !!
+    implementation("io.springfox:springfox-swagger-ui:3.0.0")
+    implementation("io.springfox:springfox-swagger2:3.0.0")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.6")
+    implementation("org.springdoc:springdoc-openapi-data-rest:1.6.5")
+    implementation("org.springdoc:springdoc-openapi-kotlin:1.6.5")
+{{/include-swagger}}
 }

--- a/src/main/resources/entry-point/rest-webflux/build.gradle.mustache
+++ b/src/main/resources/entry-point/rest-webflux/build.gradle.mustache
@@ -3,4 +3,8 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+{{#include-swagger}}
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+{{/include-swagger}}
 }

--- a/src/main/resources/entry-point/swagger/definition.json
+++ b/src/main/resources/entry-point/swagger/definition.json
@@ -1,0 +1,11 @@
+{
+  "folders": [
+  ],
+  "files": {},
+  "java": {
+    "entry-point/swagger/spring-fox-config.java.mustache": "infrastructure/entry-points/{{module}}/src/main/{{language}}/{{packagePath}}/config/SpringFoxConfig.java"
+  },
+  "kotlin": {
+    "entry-point/swagger/spring-fox-config.kt.mustache": "infrastructure/entry-points/{{module}}/src/main/{{language}}/{{packagePath}}/config/SpringFoxConfig.kt"
+  }
+}

--- a/src/main/resources/entry-point/swagger/spring-fox-config.java.mustache
+++ b/src/main/resources/entry-point/swagger/spring-fox-config.java.mustache
@@ -1,0 +1,21 @@
+package {{package}}.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SpringFoxConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/src/main/resources/entry-point/swagger/spring-fox-config.kt.mustache
+++ b/src/main/resources/entry-point/swagger/spring-fox-config.kt.mustache
@@ -1,0 +1,21 @@
+package {{package}}.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.builders.PathSelectors
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2
+
+@Configuration
+@EnableSwagger2
+open class SpringFoxConfig {
+
+    @Bean
+    open fun api(): Docket = Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build()
+}

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointKotlinTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointKotlinTaskTest.java
@@ -21,7 +21,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-public class GenerateEntryPointTaskTest {
+public class GenerateEntryPointKotlinTaskTest {
   private GenerateEntryPointTask task;
 
   @Before
@@ -35,6 +35,7 @@ public class GenerateEntryPointTaskTest {
     project.getTasks().create("ca", GenerateStructureTask.class);
     GenerateStructureTask caTask = (GenerateStructureTask) project.getTasks().getByName("ca");
     caTask.setType(type);
+    caTask.setLanguage(GenerateStructureTask.Language.KOTLIN);
     caTask.generateStructureTask();
 
     ProjectBuilder.builder()
@@ -107,15 +108,15 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/my-entry-point/build.gradle")
+        new File("build/unitTest/infrastructure/entry-points/my-entry-point/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/my-entry-point/src/main/java/co/com/bancolombia/myentrypoint")
+                "build/unitTest/infrastructure/entry-points/my-entry-point/src/main/kotlin/co/com/bancolombia/myentrypoint")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/my-entry-point/src/test/java/co/com/bancolombia/myentrypoint")
+                "build/unitTest/infrastructure/entry-points/my-entry-point/src/test/kotlin/co/com/bancolombia/myentrypoint")
             .exists());
   }
 
@@ -128,15 +129,15 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/rsocket-responder/build.gradle")
+        new File("build/unitTest/infrastructure/entry-points/rsocket-responder/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/rsocket-responder/src/main/java/co/com/bancolombia/controller/RsocketController.java")
+                "build/unitTest/infrastructure/entry-points/rsocket-responder/src/main/kotlin/co/com/bancolombia/controller/RsocketController.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/rsocket-responder/src/test/java/co/com/bancolombia/controller")
+                "build/unitTest/infrastructure/entry-points/rsocket-responder/src/test/kotlin/co/com/bancolombia/controller")
             .exists());
   }
 
@@ -149,14 +150,15 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/graphql-api/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiQueries.java")
+        new File("build/unitTest/infrastructure/entry-points/graphql-api/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/graphql-api/src/main/java/co/com/bancolombia/graphqlapi/ApiMutations.java")
+                "build/unitTest/infrastructure/entry-points/graphql-api/src/main/kotlin/co/com/bancolombia/graphqlapi/ApiQueries.kt")
+            .exists());
+    assertTrue(
+        new File(
+                "build/unitTest/infrastructure/entry-points/graphql-api/src/main/kotlin/co/com/bancolombia/graphqlapi/ApiMutations.kt")
             .exists());
   }
 
@@ -168,14 +170,14 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/test/kotlin/co/com/bancolombia/api")
             .exists());
   }
 
@@ -189,18 +191,18 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/test/kotlin/co/com/bancolombia/api")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/config/SpringFoxConfig.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/config/SpringFoxConfig.kt")
             .exists());
   }
 
@@ -213,27 +215,27 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/test/kotlin/co/com/bancolombia/api")
             .exists());
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/applications/app-service/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-undertow"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/applications/app-service/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains(
-                "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+                "exclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")"));
   }
 
   @Test
@@ -245,27 +247,27 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/test/kotlin/co/com/bancolombia/api")
             .exists());
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/applications/app-service/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-jetty"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/applications/app-service/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains(
-                "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+                "exclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")"));
   }
 
   @Test
@@ -277,19 +279,19 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts").exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/api-rest/src/test/java/co/com/bancolombia/api")
+                "build/unitTest/infrastructure/entry-points/api-rest/src/test/kotlin/co/com/bancolombia/api")
             .exists());
 
     assertFalse(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/applications/app-service/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains(
                 "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
@@ -306,18 +308,19 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle.kts")
+            .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/ApiRest.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
             .exists());
     assertFalse(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/RouterRest.kt")
             .exists());
     assertFalse(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/Handler.kt")
             .exists());
   }
 
@@ -333,22 +336,23 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/ApiRest.java")
-            .exists());
-    assertFalse(
-        new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
-            .exists());
-    assertFalse(
-        new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java")
+        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/config/SpringFoxConfig.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/ApiRest.kt")
+            .exists());
+    assertFalse(
+        new File(
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/RouterRest.kt")
+            .exists());
+    assertFalse(
+        new File(
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/Handler.kt")
+            .exists());
+    assertTrue(
+        new File(
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/config/SpringFoxConfig.kt")
             .exists());
   }
 
@@ -364,14 +368,15 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
+        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/RouterRest.kt")
+            .exists());
+    assertTrue(
+        new File(
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/Handler.kt")
             .exists());
   }
 
@@ -386,14 +391,15 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/RouterRest.java")
+        new File("build/unitTest/infrastructure/entry-points/reactive-web/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/Handler.java")
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/RouterRest.kt")
+            .exists());
+    assertTrue(
+        new File(
+                "build/unitTest/infrastructure/entry-points/reactive-web/src/main/kotlin/co/com/bancolombia/api/Handler.kt")
             .exists());
   }
 
@@ -406,23 +412,23 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/async-event-handler/build.gradle")
+        new File("build/unitTest/infrastructure/entry-points/async-event-handler/build.gradle.kts")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/HandlerRegistryConfiguration.java")
+                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/kotlin/co/com/bancolombia/events/HandlerRegistryConfiguration.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/EventsHandler.java")
+                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/kotlin/co/com/bancolombia/events/handlers/EventsHandler.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/CommandsHandler.java")
+                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/kotlin/co/com/bancolombia/events/handlers/CommandsHandler.kt")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/java/co/com/bancolombia/events/handlers/QueriesHandler.java")
+                "build/unitTest/infrastructure/entry-points/async-event-handler/src/main/kotlin/co/com/bancolombia/events/handlers/QueriesHandler.kt")
             .exists());
   }
 
@@ -436,10 +442,11 @@ public class GenerateEntryPointTaskTest {
     task.generateEntryPointTask();
     // Assert
     assertTrue(
-        new File("build/unitTest/infrastructure/entry-points/mq-listener/build.gradle").exists());
+        new File("build/unitTest/infrastructure/entry-points/mq-listener/build.gradle.kts")
+            .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/entry-points/mq-listener/src/main/java/co/com/bancolombia/mq/listener/SampleMQMessageListener.java")
+                "build/unitTest/infrastructure/entry-points/mq-listener/src/main/kotlin/co/com/bancolombia/mq/listener/SampleMQMessageListener.kt")
             .exists());
   }
 


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
add option for swagger in the entry point restmvc and webflux, to configure swagger documentation on "rest-controllers", the documentation will tobe in url http://host:port/swagger-ui.html

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [ ] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
