### PR TITLE
Feature upgrade commons jms

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 package=co.com.bancolombia
-systemProp.version=2.2.4
+systemProp.version=2.2.6
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 package=co.com.bancolombia
-systemProp.version=2.2.6
+systemProp.version=2.2.4
 

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -29,7 +29,7 @@ public class Constants {
           + "}";
   public static final String TOMCAT_EXCLUSION =
       "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
-  public static final String COMMONS_JMS_VERSION = "0.1.2";
+  public static final String COMMONS_JMS_VERSION = "0.2.0";
 
   public enum BooleanOption {
     TRUE,

--- a/src/main/resources/driven-adapter/mq-sender/definition.json
+++ b/src/main/resources/driven-adapter/mq-sender/definition.json
@@ -1,10 +1,13 @@
 {
   "folders": [
-    "infrastructure/driven-adapters/mq-sender/src/test/{{language}}/{{packagePath}}/mq/sender"
+    "infrastructure/driven-adapters/mq-sender/src/test/{{language}}/{{packagePath}}/mq/sender",
+    "infrastructure/driven-adapters/mq-sender/src/test/{{language}}/{{packagePath}}/mq/reqreply"
   ],
   "files": {},
   "java": {
     "driven-adapter/mq-sender/sample-mq-message-sender.java.mustache": "infrastructure/driven-adapters/mq-sender/src/main/{{language}}/{{packagePath}}/mq/sender/SampleMQMessageSender.java",
+    "driven-adapter/mq-sender/req-reply-gateway.java.mustache": "infrastructure/driven-adapters/mq-sender/src/main/{{language}}/{{packagePath}}/mq/reqreply/ReqReplyGateway.java",
+    "driven-adapter/mq-sender/sample-mq-req-reply.java.mustache": "infrastructure/driven-adapters/mq-sender/src/main/{{language}}/{{packagePath}}/mq/reqreply/SampleMQReqReply.java",
     "driven-adapter/mq-sender/build.gradle.mustache": "infrastructure/driven-adapters/mq-sender/build.gradle"
   },
   "kotlin": {

--- a/src/main/resources/driven-adapter/mq-sender/req-reply-gateway.java.mustache
+++ b/src/main/resources/driven-adapter/mq-sender/req-reply-gateway.java.mustache
@@ -1,0 +1,17 @@
+package {{package}}.mq.reqreply;
+
+import co.com.bancolombia.commons.jms.mq.ReqReply;
+import reactor.core.publisher.Mono;
+
+import javax.jms.Message;
+
+@ReqReply(requestQueue = "DEV.QUEUE.1") // TODO: Change the queue name, or use from properties like ${my.queue}
+public interface ReqReplyGateway {
+    Mono<Message> requestReply(String message);
+// You can use one of the next alternatives
+//    Mono<Message> requestReply(String message, Duration timeout);
+//
+//    Mono<Message> requestReply(MQMessageCreator messageCreator);
+//
+//    Mono<Message> requestReply(MQMessageCreator messageCreator, Duration timeout);
+}

--- a/src/main/resources/driven-adapter/mq-sender/sample-mq-req-reply.java.mustache
+++ b/src/main/resources/driven-adapter/mq-sender/sample-mq-req-reply.java.mustache
@@ -1,0 +1,50 @@
+package {{package}}.mq.reqreply;
+
+import co.com.bancolombia.commons.jms.mq.EnableReqReply;
+{{#lombok}}
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+{{/lombok}}
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+@Component
+{{#lombok}}
+@AllArgsConstructor
+{{/lombok}}
+@EnableReqReply
+public class SampleMQReqReply /* implements SomeGateway */ {
+    private final ReqReplyGateway sender;
+    {{^lombok}}
+
+    public SampleMQReqReply(ReqReplyGateway sender) {
+        this.sender = sender;
+    }
+    {{/lombok}}
+
+    public Mono<String> doRequest(String message) {
+        return sender.requestReply(message)
+                .map(this::extractResponse);
+    }
+
+    {{#lombok}}
+    @SneakyThrows
+    {{/lombok}}
+    private String extractResponse(Message message) {
+        {{#lombok}}
+        TextMessage textMessage = (TextMessage) message;
+        return textMessage.getText();
+        {{/lombok}}
+        {{^lombok}}
+        try {
+            TextMessage textMessage = (TextMessage) message;
+            return textMessage.getText();
+        } catch (JMSException e) {
+            throw new JMSRuntimeException(e.getMessage(), e.getErrorCode(), e);
+        }
+        {{/lombok}}
+    }
+}


### PR DESCRIPTION
## Description
This update upgrades the mq driven adapter for `java`, and it defines the new request reply abstraction.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
