### PR TITLE
Fix Duration class import in redis adapter close #162

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - feature/*
+      - fix/*
 
   pull_request:
     branches:

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/helper/reactive-template-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/helper/reactive-template-adapter-operations.java.mustache
@@ -8,6 +8,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.ParameterizedType;
+import java.time.Duration;
 import java.util.function.Function;
 
 public abstract class ReactiveTemplateAdapterOperations<E, K, V> {


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Add missing import for Duration class closes #162 

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
