### PR TITLE
fix server exclusions for restmvc entrypoint close #182

### DIFF
--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -10,8 +10,6 @@ public class Constants {
   public static final String PATH_GRAPHQL = "/graphqlpath";
   public static final String SECRETS_VERSION = "3.0.0";
   public static final String SPRING_BOOT_VERSION = "2.6.7";
-  public static final String UNDERTOW_VERSION = "2.6.7";
-  public static final String JETTY_VERSION = "2.6.7";
   public static final String SONAR_VERSION = "3.0";
   public static final String LOMBOK_VERSION = "1.18.22";
   public static final String JACOCO_VERSION = "0.8.5";
@@ -28,7 +26,7 @@ public class Constants {
           + "\t}\n"
           + "}";
   public static final String TOMCAT_EXCLUSION =
-      "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"";
+      "implementation.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'";
   public static final String COMMONS_JMS_VERSION = "0.2.0";
 
   public enum BooleanOption {

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvcServer.java
@@ -1,38 +1,40 @@
 package co.com.bancolombia.factory.entrypoints;
 
-import static co.com.bancolombia.Constants.APP_SERVICE;
 import static co.com.bancolombia.utils.Utils.buildImplementation;
 import static co.com.bancolombia.utils.Utils.tomcatExclusion;
 
-import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.InvalidTaskOptionException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
+import co.com.bancolombia.utils.Utils;
 import java.io.IOException;
 
 public class EntryPointRestMvcServer implements ModuleFactory {
+  private static final String BUILD_GRADLE = "infrastructure/entry-points/api-rest/build.gradle";
+  private static final String BUILD_GRADLE_KTS =
+      "infrastructure/entry-points/api-rest/build.gradle.kts";
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, InvalidTaskOptionException {
     Server server = (Server) builder.getParam("task-param-server");
+    String file = builder.isKotlin() ? BUILD_GRADLE_KTS : BUILD_GRADLE;
 
     switch (server) {
       case UNDERTOW:
         String undertowDependency =
             buildImplementation(
-                builder.isKotlin(),
-                "org.springframework.boot:spring-boot-starter-undertow:"
-                    + Constants.UNDERTOW_VERSION);
-        builder.appendDependencyToModule(APP_SERVICE, undertowDependency);
-        builder.appendConfigurationToModule(APP_SERVICE, tomcatExclusion(builder.isKotlin()));
+                builder.isKotlin(), "org.springframework.boot:spring-boot-starter-undertow");
+        builder.updateFile(file, current -> Utils.addDependency(current, undertowDependency));
+        builder.updateFile(
+            file, current -> Utils.addConfiguration(current, tomcatExclusion(builder.isKotlin())));
         return;
       case JETTY:
         String jettyDependency =
             buildImplementation(
-                builder.isKotlin(),
-                "org.springframework.boot:spring-boot-starter-jetty:" + Constants.JETTY_VERSION);
-        builder.appendDependencyToModule(APP_SERVICE, jettyDependency);
-        builder.appendConfigurationToModule(APP_SERVICE, tomcatExclusion(builder.isKotlin()));
+                builder.isKotlin(), "org.springframework.boot:spring-boot-starter-jetty");
+        builder.updateFile(file, current -> Utils.addDependency(current, jettyDependency));
+        builder.updateFile(
+            file, current -> Utils.addConfiguration(current, tomcatExclusion(builder.isKotlin())));
         return;
       case TOMCAT:
         return;

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2022M05D02.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2022M05D02.java
@@ -31,5 +31,6 @@ public class UpgradeY2022M05D02 implements UpgradeAction {
     UpdateUtils.updateConfiguration(builder, file, "runtime", "runtimeOnly");
     UpdateUtils.updateConfiguration(builder, file, "testRuntime", "testRuntimeOnly");
     UpdateUtils.updateConfiguration(builder, file, "testCompile", "testImplementation");
+    builder.updateExpression(file, "compile.exclude", "implementation.exclude");
   }
 }

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointKotlinTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointKotlinTaskTest.java
@@ -227,12 +227,12 @@ public class GenerateEntryPointKotlinTaskTest {
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle.kts"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-undertow"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle.kts"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains(
                 "exclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")"));
@@ -259,12 +259,12 @@ public class GenerateEntryPointKotlinTaskTest {
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle.kts"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-jetty"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle.kts"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle.kts"),
                 StandardCharsets.UTF_8)
             .contains(
                 "exclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")"));

--- a/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateEntryPointTaskTest.java
@@ -226,15 +226,15 @@ public class GenerateEntryPointTaskTest {
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-undertow"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle"),
                 StandardCharsets.UTF_8)
             .contains(
-                "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+                "implementation.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'"));
   }
 
   @Test
@@ -258,15 +258,15 @@ public class GenerateEntryPointTaskTest {
 
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle"),
                 StandardCharsets.UTF_8)
             .contains("spring-boot-starter-jetty"));
     assertTrue(
         FileUtils.readFileToString(
-                new File("build/unitTest/applications/app-service/build.gradle"),
+                new File("build/unitTest/infrastructure/entry-points/api-rest/build.gradle"),
                 StandardCharsets.UTF_8)
             .contains(
-                "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\""));
+                "implementation.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'"));
   }
 
   @Test

--- a/src/test/java/co/com/bancolombia/utils/UtilsTest.java
+++ b/src/test/java/co/com/bancolombia/utils/UtilsTest.java
@@ -389,7 +389,7 @@ public class UtilsTest {
         result);
     result = Utils.tomcatExclusion(false);
     assertEquals(
-        "compile.exclude group: \"org.springframework.boot\", module:\"spring-boot-starter-tomcat\"",
+        "implementation.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'",
         result);
   }
 


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Move tomcat exclusion to entry point build gradle file closes #182 
Add upgrade step to migrate from gradle 6 to 7

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [x] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
