### PR TITLE
Fix security alerts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.3.4   | :white_check_mark: |
+| 2.3.3   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+This repository runs security code scanning weekly to identify vulnerabilities. 
+If you want to report a vulnerability, please create an issue with a clear description and we will try to fix it.

--- a/examples-ca/channel-operations/deployment/Dockerfile
+++ b/examples-ca/channel-operations/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8-openj9:alpine-slim
+FROM adoptopenjdk/openjdk8-openj9@sha256:75225e1550aab2a1c57c806d18ed301419cc6dcadb521effe7dc0652a160a3a1
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-article/deployment/Dockerfile
+++ b/examples-ca/example-article/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar crudTest.jar
 RUN sh -c 'touch /crudTest.jar'

--- a/examples-ca/example-dynamo/deployment/Dockerfile
+++ b/examples-ca/example-dynamo/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-mongo/deployment/Dockerfile
+++ b/examples-ca/example-mongo/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-r2dbc/deployment/Dockerfile
+++ b/examples-ca/example-r2dbc/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-redis/deployment/Dockerfile
+++ b/examples-ca/example-redis/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-rest-consumer/rest-consumer-client/deployment/Dockerfile
+++ b/examples-ca/example-rest-consumer/rest-consumer-client/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/example-rest-consumer/rest-consumer-server/deployment/Dockerfile
+++ b/examples-ca/example-rest-consumer/rest-consumer-server/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/examples-ca/s3-example/deployment/Dockerfile
+++ b/examples-ca/s3-example/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
+FROM adoptopenjdk/openjdk11-openj9@sha256:15eb4c70a455781ecc93fcfad548502f78a9c0fb3fe727fd3199ff38d7b09279
 VOLUME /tmp
 COPY *.jar app.jar
 RUN sh -c 'touch /app.jar'

--- a/gradlew
+++ b/gradlew
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MSYS* | MINGW* )
+  MINGW* )
     msys=true
     ;;
   NONSTOP* )


### PR DESCRIPTION
## Description
Update Dockerfiles to use hash digest and fix this security alert:

* [Pinned-Dependencies](https://github.com/bancolombia/scaffold-clean-architecture/security/code-scanning/35)

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
