### PR TITLE
fix unit tests

### DIFF
--- a/src/main/java/co/com/bancolombia/utils/FileUtils.java
+++ b/src/main/java/co/com/bancolombia/utils/FileUtils.java
@@ -88,7 +88,10 @@ public class FileUtils {
     if (path.startsWith("./")) {
       return path;
     }
-    if (path.startsWith("/")) {
+    if (path.startsWith(".\\")) {
+      return path;
+    }
+    if (Paths.get(path).isAbsolute()) {
       return path;
     }
     return "./" + path;

--- a/src/main/java/co/com/bancolombia/utils/Utils.java
+++ b/src/main/java/co/com/bancolombia/utils/Utils.java
@@ -167,6 +167,8 @@ public class Utils {
               .filter(f -> f.endsWith(extension) && !f.contains(".git"))
               .filter(f -> !f.contains(".git"))
               .filter(f -> !f.contains("settings.gradle"))
+              .map(f -> f.replace("\\", "/"))
+              .filter(f -> !f.contains("/bin"))
               .filter(f -> !f.contains("/resources"))
               .filter(f -> !f.contains("/examples-ca"))
               .map(p -> p.replace("build/functionalTest/", ""))


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Fix issue #245 
Some IDEs like VSCode or Eclipse use the bin folder to compile and use resources. The plugin searches all the files by specific extension and concatenates it to the root of the test project, which generates an inconsistency in the file path, so the valid directories for file search are filtered.
Absolute paths in windows contain a disk letter is solved by validating the type of path.

## Category
- [ ] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
