### PR TITLE
update r2dbc driven adapter, use new r2dbc postgresql library

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 package=co.com.bancolombia
-systemProp.version=2.4.9
+systemProp.version=2.4.8
 simulateRest=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 package=co.com.bancolombia
-systemProp.version=2.4.8
+systemProp.version=2.4.9
 simulateRest=true

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/build.gradle.mustache
@@ -2,6 +2,9 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
-    implementation 'io.r2dbc:r2dbc-postgresql'
+    implementation 'org.postgresql:r2dbc-postgresql'
+    implementation 'org.reactivecommons.utils:object-mapper-api:{{objectMapperVersion}}'
+
+    testImplementation 'org.reactivecommons.utils:object-mapper:{{objectMapperVersion}}'
 }
 

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.java.mustache
@@ -1,4 +1,4 @@
-package {{package}}.config;
+package {{package}}.r2dbc.config;
 
 import java.time.Duration;
 import io.r2dbc.pool.ConnectionPool;

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-properties.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-properties.java.mustache
@@ -1,4 +1,4 @@
-package {{package}}.config;
+package {{package}}.r2dbc.config;
 
 {{#lombok}}
 import lombok.AllArgsConstructor;

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/definition.json
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/definition.json
@@ -5,9 +5,11 @@
   ],
   "files": {},
   "java": {
-    "driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/config/PostgreSQLConnectionPool.java",
-    "driven-adapter/r2dbc-postgresql/config/postgresql-connection-properties.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/config/PostgresqlConnectionProperties.java",
-    "driven-adapter/r2dbc-postgresql/my-reactive-repository.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/MyReactiveRepository.java",
+    "driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/config/PostgreSQLConnectionPool.java",
+    "driven-adapter/r2dbc-postgresql/config/postgresql-connection-properties.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/config/PostgresqlConnectionProperties.java",
+    "driven-adapter/r2dbc-postgresql/helper/reactive-adapter-operations.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/helper/ReactiveAdapterOperations.java",
+    "driven-adapter/r2dbc-postgresql/my-reactive-repository.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/MyReactiveRepository.java",
+    "driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/MyReactiveRepositoryAdapter.java",
     "driven-adapter/r2dbc-postgresql/build.gradle.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/build.gradle"
   },
   "kotlin": {

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/helper/reactive-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/helper/reactive-adapter-operations.java.mustache
@@ -1,0 +1,66 @@
+package {{package}}.r2dbc.helper;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.function.Function;
+
+public abstract class ReactiveAdapterOperations<E, D, I, R extends ReactiveCrudRepository<D, I> & ReactiveQueryByExampleExecutor<D>> {
+    protected R repository;
+    protected ObjectMapper mapper;
+    private final Class<D> dataClass;
+    private final Function<D, E> toEntityFn;
+
+    public ReactiveAdapterOperations(R repository, ObjectMapper mapper, Function<D, E> toEntityFn) {
+        this.repository = repository;
+        this.mapper = mapper;
+        ParameterizedType genericSuperclass = (ParameterizedType) this.getClass().getGenericSuperclass();
+        this.dataClass = (Class<D>) genericSuperclass.getActualTypeArguments()[1];
+        this.toEntityFn = toEntityFn;
+    }
+
+    protected D toData(E entity) {
+        return mapper.map(entity, dataClass);
+    }
+
+    protected E toEntity(D data) {
+        return data != null ? toEntityFn.apply(data) : null;
+    }
+
+    public Mono<E> save(E entity) {
+        return saveData(toData(entity))
+                .map(this::toEntity);
+    }
+
+    protected Flux<E> saveAllEntities(Flux<E> entities) {
+        return saveData(entities.map(this::toData))
+                .map(this::toEntity);
+    }
+
+    protected Mono<D> saveData(D data) {
+        return repository.save(data);
+    }
+
+    protected Flux<D> saveData(Flux<D> data) {
+        return repository.saveAll(data);
+    }
+
+    public Mono<E> findById(I id) {
+        return repository.findById(id).map(this::toEntity);
+    }
+
+    public Flux<E> findByExample(E entity) {
+        return repository.findAll(Example.of(toData(entity)))
+                .map(this::toEntity);
+    }
+
+    public Flux<E> findAll() {
+        return repository.findAll()
+                .map(this::toEntity);
+    }
+}

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.java.mustache
@@ -1,0 +1,20 @@
+package {{package}}.r2dbc;
+
+import {{package}}.r2dbc.helper.ReactiveAdapterOperations;
+import org.reactivecommons.utils.ObjectMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MyReactiveRepositoryAdapter extends ReactiveAdapterOperations<Object/* change for domain model */, Object/* change for adapter model */, String, MyReactiveRepository>
+// implements ModelRepository from domain
+{
+    public MyReactiveRepositoryAdapter(MyReactiveRepository repository, ObjectMapper mapper) {
+        /**
+         *  Could be use mapper.mapBuilder if your domain model implement builder pattern
+         *  super(repository, mapper, d -> mapper.mapBuilder(d,ObjectModel.ObjectModelBuilder.class).build());
+         *  Or using mapper.map with the class of the object model
+         */
+        super(repository, mapper, d -> mapper.map(d, Object.class/* change for domain model */));
+    }
+
+}

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository.java.mustache
@@ -5,6 +5,6 @@ import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 // TODO: This file is just an example, you should delete or modify it
-public interface MyReactiveRepository extends ReactiveCrudRepository<Object, String> {
+public interface MyReactiveRepository extends ReactiveCrudRepository<Object, String>, ReactiveQueryByExampleExecutor<Object> {
 
 }

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -493,15 +493,19 @@ public class GenerateDrivenAdapterTaskTest {
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/config/PostgreSQLConnectionPool.java")
+                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/config/PostgreSQLConnectionPool.java")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/config/PostgresqlConnectionProperties.java")
+                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/config/PostgresqlConnectionProperties.java")
             .exists());
     assertTrue(
         new File(
-                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/MyReactiveRepository.java")
+                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/MyReactiveRepository.java")
+            .exists());
+    assertTrue(
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/MyReactiveRepositoryAdapter.java")
             .exists());
   }
 


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Update r2dbc driven adapter, this change includes:
- Use of ReactiveRepositoryAdapter
- Change of dependency `io.r2dbc:r2dbc-postgresql` for `org.postgresql:r2dbc-postgresql`

## Category
- [x] Feature
- [x] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
