### PR TITLE
Redis repository update

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,0 +1,6 @@
+# TODO
+
+## Redis -> imperative repository
+- Update package javax.persistence.* to jakarta.persistence.*
+- Update org.springframework.data.repository.CrudRepository by org.springframework.data.keyvalue.repository.KeyValueRepository
+- Add dependency implementation 'jakarta.persistence:jakarta.persistence-api'

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -4,6 +4,7 @@ import static co.com.bancolombia.Constants.APP_SERVICE;
 import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
 
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
@@ -15,6 +16,11 @@ public class DrivenAdapterRedis implements ModuleFactory {
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+    if (builder.isReactive() && Mode.REPOSITORY == builder.getParam(PARAM_MODE)) {
+      // https://github.com/spring-projects/spring-data-redis/issues/1823
+      throw new ValidationException(
+          "This mode is only available for imperative projects, please use `template` mode");
+    }
     Logger logger = builder.getProject().getLogger();
     String typePath = getPathType(builder.isReactive());
     String modePath = getPathMode((Mode) builder.getParam(PARAM_MODE));

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.unit.test.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.unit.test.java.mustache
@@ -1,0 +1,15 @@
+package {{package}}.r2dbc.config;
+
+import {{package}}.r2dbc.config.PostgreSQLConnectionPool;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PostgreSQLConnectionPoolTest {
+
+    // TODO: change four you own tests
+    @Test
+    void getConnectionConfig() {
+        PostgreSQLConnectionPool postgreSQLConnectionPool= new PostgreSQLConnectionPool();
+        Assertions.assertNotNull(postgreSQLConnectionPool.getConnectionConfig());
+    }
+}

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/definition.json
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/definition.json
@@ -6,10 +6,12 @@
   "files": {},
   "java": {
     "driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/config/PostgreSQLConnectionPool.java",
+    "driven-adapter/r2dbc-postgresql/config/postgresql-connection-pool.unit.test.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/test/{{language}}/{{packagePath}}/r2dbc/PostgreSQLConnectionPoolTest.java",
     "driven-adapter/r2dbc-postgresql/config/postgresql-connection-properties.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/config/PostgresqlConnectionProperties.java",
     "driven-adapter/r2dbc-postgresql/helper/reactive-adapter-operations.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/helper/ReactiveAdapterOperations.java",
     "driven-adapter/r2dbc-postgresql/my-reactive-repository.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/MyReactiveRepository.java",
     "driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/main/{{language}}/{{packagePath}}/r2dbc/MyReactiveRepositoryAdapter.java",
+    "driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.unit.test.java.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/src/test/{{language}}/{{packagePath}}/r2dbc/MyReactiveRepositoryAdapterTest.java",
     "driven-adapter/r2dbc-postgresql/build.gradle.mustache": "infrastructure/driven-adapters/r2dbc-postgresql/build.gradle"
   },
   "kotlin": {

--- a/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.unit.test.java.mustache
+++ b/src/main/resources/driven-adapter/r2dbc-postgresql/my-reactive-repository-adapter.unit.test.java.mustache
@@ -1,0 +1,41 @@
+package {{package}}.r2dbc;
+
+import {{package}}.r2dbc.MyReactiveRepository;
+import {{package}}.r2dbc.MyReactiveRepositoryAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivecommons.utils.ObjectMapper;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MyReactiveRepositoryAdapterTest {
+    // TODO: change four you own tests
+
+    @InjectMocks
+    MyReactiveRepositoryAdapter repositoryAdapter;
+
+    @Mock
+    MyReactiveRepository repository;
+
+    @Mock
+    ObjectMapper mapper;
+
+    @Test
+    void mustFindValueById() {
+
+        when(repository.findById("1")).thenReturn(Mono.just("test"));
+        when(mapper.map("test", Object.class)).thenReturn("test");
+
+        Mono<Object> result = repositoryAdapter.findById("1");
+
+        StepVerifier.create(result)
+                .expectNextMatches(value -> value.equals("test"))
+                .verifyComplete();
+    }
+}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
@@ -2,7 +2,9 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    {{#include-secret}}
     implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{secretsVersion}}'
+    {{/include-secret}}
     implementation 'org.reactivecommons.utils:object-mapper-api:{{objectMapperVersion}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{objectMapperVersion}}'

--- a/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
@@ -1,7 +1,10 @@
 dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
+    {{#include-secret}}
     implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{secretsVersion}}'
+    {{/include-secret}}
     implementation 'org.reactivecommons.utils:object-mapper-api:{{objectMapperVersion}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{objectMapperVersion}}'

--- a/src/main/resources/driven-adapter/redis/redis-repository/definition.json
+++ b/src/main/resources/driven-adapter/redis/redis-repository/definition.json
@@ -7,6 +7,7 @@
     "driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache": "infrastructure/driven-adapters/redis/src/main/{{language}}/{{packagePath}}/redis/repository/helper/RepositoryAdapterOperations.java",
     "driven-adapter/redis/redis-repository/redis-repository.java.mustache": "infrastructure/driven-adapters/redis/src/main/{{language}}/{{packagePath}}/redis/repository/RedisRepository.java",
     "driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache": "infrastructure/driven-adapters/redis/src/main/{{language}}/{{packagePath}}/redis/repository/RedisRepositoryAdapter.java",
+    "driven-adapter/redis/redis-repository/model-dto.java.mustache": "infrastructure/driven-adapters/redis/src/main/{{language}}/{{packagePath}}/redis/repository/ModelDTO.java",
     "driven-adapter/redis/redis-repository/build.gradle.mustache": "infrastructure/driven-adapters/redis/build.gradle"
   },
   "kotlin": {

--- a/src/main/resources/driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/helper/repository-adapter-operations.java.mustache
@@ -2,7 +2,7 @@ package {{package}}.redis.repository.helper;
 
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.data.domain.Example;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 
 import java.lang.reflect.ParameterizedType;
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.StreamSupport.stream;
 
-public abstract class RepositoryAdapterOperations<E, D, I, R extends CrudRepository<D, I> & QueryByExampleExecutor<D>> {
+public abstract class RepositoryAdapterOperations<E, D, I, R extends KeyValueRepository<D, I> & QueryByExampleExecutor<D>> {
     protected R repository;
     private final Class<D> dataClass;
     protected ObjectMapper mapper;

--- a/src/main/resources/driven-adapter/redis/redis-repository/model-dto.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/model-dto.java.mustache
@@ -1,0 +1,49 @@
+package {{package}}.redis.repository;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.Entity;
+{{#lombok}}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+{{/lombok}}
+
+{{#lombok}}
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+{{/lombok}}
+@Entity // TODO: Or you can use @RedisHash
+public class ModelDTO {
+    @Id
+    private String id;
+    private String name;
+    {{^lombok}}
+
+    public SampleDTO() {
+    }
+
+    public SampleDTO(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    {{/lombok}}
+}

--- a/src/main/resources/driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/redis-repository-adapter.java.mustache
@@ -5,7 +5,7 @@ import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class RedisRepositoryAdapter extends RepositoryAdapterOperations<Object/* change for domain model */, Object/* change for adapter model */, String, RedisRepository>
+public class RedisRepositoryAdapter extends RepositoryAdapterOperations<Object/* change for domain model */, ModelDTO/* change for adapter model */, String, RedisRepository>
 // implements ModelRepository from domain
 {
 

--- a/src/main/resources/driven-adapter/redis/redis-repository/redis-repository.java.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/redis-repository.java.mustache
@@ -1,7 +1,7 @@
 package {{package}}.redis.repository;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 
-public interface RedisRepository extends CrudRepository<Object/* change for adapter model */, String>, QueryByExampleExecutor<Object/* change for adapter model */> {
+public interface RedisRepository extends KeyValueRepository<ModelDTO/* change for adapter model */, String>, QueryByExampleExecutor<ModelDTO/* change for adapter model */> {
 }

--- a/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
@@ -2,7 +2,9 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    {{#include-secret}}
     implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{secretsVersion}}'
+    {{/include-secret}}
     implementation 'org.reactivecommons.utils:object-mapper-api:{{objectMapperVersion}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{objectMapperVersion}}'

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterKotlinTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterKotlinTaskTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.adapters.DrivenAdapterRedis;
 import co.com.bancolombia.factory.adapters.ModuleFactoryDrivenAdapter;
 import java.io.File;
@@ -386,7 +387,7 @@ public class GenerateDrivenAdapterKotlinTaskTest {
             .exists());
   }
 
-  @Test
+  @Test(expected = ValidationException.class)
   public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret()
       throws IOException, CleanException {
     // Arrange
@@ -396,25 +397,6 @@ public class GenerateDrivenAdapterKotlinTaskTest {
     task.setSecret(Constants.BooleanOption.TRUE);
     // Act
     task.generateDrivenAdapterTask();
-    // Assert
-    assertTrue(
-        new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle.kts").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/kotlin/co/com/bancolombia/redis/repository/helper/ReactiveRepositoryAdapterOperations.kt")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/kotlin/co/com/bancolombia/redis/repository/ReactiveRedisRepository.kt")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/kotlin/co/com/bancolombia/redis/repository/ReactiveRedisRepositoryAdapter.kt")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/kotlin/co/com/bancolombia/redis/config/RedisConfig.kt")
-            .exists());
   }
 
   @Test

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -412,7 +412,7 @@ public class GenerateDrivenAdapterTaskTest {
             .exists());
   }
 
-  @Test
+  @Test(expected = ValidationException.class)
   public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret()
       throws IOException, CleanException {
     // Arrange
@@ -422,25 +422,6 @@ public class GenerateDrivenAdapterTaskTest {
     task.setSecret(Constants.BooleanOption.TRUE);
     // Act
     task.generateDrivenAdapterTask();
-    // Assert
-    assertTrue(
-        new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/ReactiveRepositoryAdapterOperations.java")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/ReactiveRedisRepository.java")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/ReactiveRedisRepositoryAdapter.java")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/config/RedisConfig.java")
-            .exists());
   }
 
   @Test


### PR DESCRIPTION
Features:
- Removed redis reactive reactive because it is not supported by spring boot.
- Removed secrets dependency when not needed.
- Replace javax by jakarta (add explicit dependency).