### PR TITLE
Use springdoc-openapi-starter to generate API documentation

### DIFF
--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
   public static final String OKHTTP_VERSION = "4.11.0";
   public static final String RESILIENCE_4J_VERSION = "2.0.2";
   public static final String BIN_STASH_VERSION = "1.2.0";
-  public static final String SPRING_FOX_VERSION = "3.0.0";
+  public static final String SPRINGDOC_OPENAPI_VERSION = "2.2.0";
   public static final String DEPENDENCY_CHECK_VERSION = "8.2.1";
   public static final String TOMCAT_EXCLUSION_KOTLIN =
       "configurations {\n"

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -92,7 +92,7 @@ public class ModuleBuilder {
     params.put("okhttpVersion", Constants.OKHTTP_VERSION);
     params.put("resilience4jVersion", Constants.RESILIENCE_4J_VERSION);
     params.put("binStashVersion", Constants.BIN_STASH_VERSION);
-    params.put("springfoxVersion", Constants.SPRING_FOX_VERSION);
+    params.put("springdocOpenapiVersion", Constants.SPRINGDOC_OPENAPI_VERSION);
     params.put("dependencyCheckVersion", Constants.DEPENDENCY_CHECK_VERSION);
     params.put("lombok", isEnableLombok());
     params.put("metrics", withMetrics());

--- a/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
+++ b/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
@@ -7,7 +7,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     {{/metrics}}
 {{#include-swagger}}
-    implementation 'io.springfox:springfox-boot-starter:{{springfoxVersion}}'
-    implementation 'io.springfox:springfox-swagger-ui:{{springfoxVersion}}'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:{{springdocopenapiVersion}}'
 {{/include-swagger}}
 }

--- a/src/main/resources/entry-point/rest-webflux/build.gradle.mustache
+++ b/src/main/resources/entry-point/rest-webflux/build.gradle.mustache
@@ -7,7 +7,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     {{/metrics}}
 {{#include-swagger}}
-    implementation 'io.springfox:springfox-boot-starter:{{springfoxVersion}}'
-    implementation 'io.springfox:springfox-swagger-ui:{{springfoxVersion}}'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:{{springdocopenapiVersion}}'
 {{/include-swagger}}
 }


### PR DESCRIPTION
## Description
Currently, the dependency used to automate the generation of API documentation [io.springfox:springfox-boot-starter](https://github.com/springfox/springfox) has not received updates since July 13, 2020, so it is recommended to replace it with [springdoc-openapi-starter](https://github.com/springdoc/springdoc-openapi), which is maintained and updated.

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
