### PR TITLE
Add authorization with jwt token in entrypoint restmvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,16 +357,16 @@ The **`generateEntryPoint | gep`** task will generate a module in Infrastructure
    gradle gep --type [entryPointType]
    ```
 
-   | Reference for **entryPointType** | Name                                   | Additional Options                       |Java   | Kotlin  |
-   |----------------------------------|----------------------------------------|------------------------------------------|-------|---------|
-   | generic                          | Empty Entry Point                      | --name [name]                            |&#9745;| &#9745; |
-   | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow |&#9745;| &#9745; |
-   | webflux                          | API REST (Spring Boot Starter WebFlux) | --router [true, false] default true      |&#9745;| &#9745; |
-   | rsocket                          | Rsocket Controller Entry Point         |                                          |&#9745;| &#9745; |
-   | graphql                          | API GraphQL                            | --pathgql [name path] default /graphql   |&#9745;| &#9745; |
-   | asynceventhandler                | Async Event Handler                    |                                          |&#9745;| &#9745; |
-   | mq                               | JMS MQ Client to listen messages       |                                          |&#9745;| &#9745; |
-   | sqs                              | SQS Listener                           |                                          |&#9745;| &#9745; |
+   | Reference for **entryPointType** | Name                                   | Additional Options                                                    |Java   | Kotlin  |
+   |----------------------------------|----------------------------------------|-----------------------------------------------------------------------|-------|---------|
+   | generic                          | Empty Entry Point                      | --name [name]                                                         |&#9745;| &#9745; |
+   | restmvc                          | API REST (Spring Boot Starter Web)     | --server [serverOption] default undertow --authorization [true-false] |&#9745;| &#9745; |
+   | webflux                          | API REST (Spring Boot Starter WebFlux) | --router [true, false] default true                                   |&#9745;| &#9745; |
+   | rsocket                          | Rsocket Controller Entry Point         |                                                                       |&#9745;| &#9745; |
+   | graphql                          | API GraphQL                            | --pathgql [name path] default /graphql                                |&#9745;| &#9745; |
+   | asynceventhandler                | Async Event Handler                    |                                                                       |&#9745;| &#9745; |
+   | mq                               | JMS MQ Client to listen messages       |                                                                       |&#9745;| &#9745; |
+   | sqs                              | SQS Listener                           |                                                                       |&#9745;| &#9745; |
 
    Additionally, if you'll use a restmvc, you can specify the web server on which the application will run. By default, undertow.
 

--- a/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
+++ b/src/main/java/co/com/bancolombia/factory/entrypoints/EntryPointRestMvc.java
@@ -32,6 +32,17 @@ public class EntryPointRestMvc implements ModuleFactory {
     } else {
       builder.appendToProperties("management.endpoints.web.exposure").put("include", "health");
     }
+
+    if (Boolean.TRUE.equals(builder.getBooleanParam("task-param-authorize"))) {
+      builder.setupFromTemplate("entry-point/rest-mvc/authorization");
+      builder
+          .appendToProperties("spring.security.oauth2.resourceserver.jwt")
+          .put("issuer-uri", "https://idp.example.com/issuer");
+      builder
+          .appendToProperties("spring.security.oauth2.resourceserver.jwt")
+          .put("client-id", "myclientid");
+      builder.appendToProperties("jwt").put("json-exp-roles", "/roles");
+    }
     builder.appendToProperties("management.endpoint.health.probes").put("enabled", true);
     builder
         .appendToProperties("cors")

--- a/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateEntryPointTask.java
@@ -20,6 +20,7 @@ public class GenerateEntryPointTask extends AbstractResolvableTypeTask {
   private BooleanOption router = BooleanOption.TRUE;
   private BooleanOption swagger = BooleanOption.FALSE;
   private BooleanOption eda = BooleanOption.FALSE;
+  private BooleanOption authorization = BooleanOption.FALSE;
 
   @Option(
       option = "server",
@@ -41,6 +42,11 @@ public class GenerateEntryPointTask extends AbstractResolvableTypeTask {
   @Option(option = "pathgql", description = "set API GraphQL path")
   public void setPathGraphql(String pathgql) {
     this.pathGraphql = pathgql;
+  }
+
+  @Option(option = "authorization", description = "Enable authorization requests through a JWT")
+  public void setAuthorization(BooleanOption authorization) {
+    this.authorization = authorization;
   }
 
   @Option(option = "eda", description = "Use EDA variant")
@@ -68,11 +74,17 @@ public class GenerateEntryPointTask extends AbstractResolvableTypeTask {
     return Arrays.asList(BooleanOption.values());
   }
 
+  @OptionValues("authorization")
+  public List<BooleanOption> getAuthorizeOptions() {
+    return Arrays.asList(BooleanOption.values());
+  }
+
   @Override
   protected void prepareParams() {
     builder.addParam("task-param-server", server);
     builder.addParam("task-param-pathgql", pathGraphql);
     builder.addParam("task-param-router", router == BooleanOption.TRUE);
+    builder.addParam("task-param-authorize", authorization == BooleanOption.TRUE);
     builder.addParam("include-swagger", swagger == BooleanOption.TRUE);
     builder.addParam("eda", eda == BooleanOption.TRUE);
   }

--- a/src/main/resources/entry-point/rest-mvc/api.java.mustache
+++ b/src/main/resources/entry-point/rest-mvc/api.java.mustache
@@ -6,6 +6,9 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+{{#task-param-authorize}}
+import org.springframework.security.access.prepost.PreAuthorize;
+{{/task-param-authorize}}
 
 @RestController
 @RequestMapping(value = "/api", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -21,6 +24,9 @@ public class ApiRest {
     //}
 {{/lombok}}
 
+{{#task-param-authorize}}
+    @PreAuthorize("hasRole('permission')")
+{{/task-param-authorize}}
     @GetMapping(path = "/path")
     public String commandName() {
 //      return useCase.doAction();

--- a/src/main/resources/entry-point/rest-mvc/authorization/authorization-jwt.java.mustache
+++ b/src/main/resources/entry-point/rest-mvc/authorization/authorization-jwt.java.mustache
@@ -1,10 +1,7 @@
 package {{package}}.api.config;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,29 +16,47 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+{{^lombok}}
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+{{/lombok}}
+{{#lombok}}
+import lombok.extern.log4j.Log4j2;
+{{/lombok}}
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+{{#lombok}}
+@Log4j2
+{{/lombok}}
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 public class AuthorizationJwt {
 
-    @Autowired
-    private ObjectMapper mapper;
-
-    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
-    private String issuerUri;
-    @Value("${spring.security.oauth2.resourceserver.jwt.client-id}")
-    private String clientId;
-    @Value("${jwt.json-exp-roles}")
-    private String jsonExpRoles;
+    {{^lombok}}
+    private static final Logger log = LogManager.getLogger(AuthorizationJwt.class);
+    {{/lombok}}
+    private final String issuerUri;
+    private final String clientId;
+    private final String jsonExpRoles;
+    private final ObjectMapper mapper;
 
     private static final String ROLE = "ROLE_";
     private static final String AZP = "azp";
+
+    public AuthorizationJwt(@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}") String issuerUri,
+                             @Value("${spring.security.oauth2.resourceserver.jwt.client-id}") String clientId,
+                             @Value("${jwt.json-exp-roles}") String jsonExpRoles,
+                             ObjectMapper mapper) {
+        this.issuerUri = issuerUri;
+        this.clientId = clientId;
+        this.jsonExpRoles = jsonExpRoles;
+        this.mapper = mapper;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -87,7 +102,7 @@ public class AuthorizationJwt {
             return mapper.readerFor(new TypeReference<List<String>>() {})
                     .readValue(chunk);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error(e.getMessage());
             return roles;
         }
     }

--- a/src/main/resources/entry-point/rest-mvc/authorization/authorization-jwt.java.mustache
+++ b/src/main/resources/entry-point/rest-mvc/authorization/authorization-jwt.java.mustache
@@ -1,0 +1,94 @@
+package {{package}}.api.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+public class AuthorizationJwt {
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+    @Value("${spring.security.oauth2.resourceserver.jwt.client-id}")
+    private String clientId;
+    @Value("${jwt.json-exp-roles}")
+    private String jsonExpRoles;
+
+    private static final String ROLE = "ROLE_";
+    private static final String AZP = "azp";
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 ->
+                        oauth2.jwt(jwtSpec ->
+                                jwtSpec
+                                .decoder(jwtDecoder())
+                                .jwtAuthenticationConverter(grantedAuthoritiesExtractor())))
+                .build();
+    }
+
+    public JwtDecoder jwtDecoder(){
+        var defaultValidator = JwtValidators.createDefaultWithIssuer(issuerUri);
+        var audienceValidator = new JwtClaimValidator<String>(AZP,
+                azp -> azp != null && !azp.isEmpty() && azp.contains(clientId));
+        var tokenValidator = new DelegatingOAuth2TokenValidator<>(defaultValidator, audienceValidator);
+        var jwtDecoder = NimbusJwtDecoder
+                .withIssuerLocation(issuerUri)
+                .build();
+        jwtDecoder.setJwtValidator(tokenValidator);
+        return jwtDecoder;
+    }
+
+    public JwtAuthenticationConverter grantedAuthoritiesExtractor(){
+        var jwtConverter = new JwtAuthenticationConverter();
+        jwtConverter.setJwtGrantedAuthoritiesConverter(jwt ->
+                getRoles(jwt.getClaims(), jsonExpRoles)
+                .stream()
+                .map(ROLE::concat)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList())
+        );
+        return jwtConverter;
+    }
+
+    private List<String> getRoles(Map<String, Object> claims, String jsonExpClaim){
+        List<String> roles = List.of();
+        try {
+            var json = mapper.writeValueAsString(claims);
+            var chunk = mapper.readTree(json)
+                    .at(jsonExpClaim);
+            return mapper.readerFor(new TypeReference<List<String>>() {})
+                    .readValue(chunk);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return roles;
+        }
+    }
+}

--- a/src/main/resources/entry-point/rest-mvc/authorization/definition.json
+++ b/src/main/resources/entry-point/rest-mvc/authorization/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    "infrastructure/entry-points/api-rest/src/test/{{language}}/{{packagePath}}/api/config"
+  ],
+  "files": {},
+  "java": {
+    "entry-point/rest-mvc/authorization/authorization-jwt.java.mustache": "infrastructure/entry-points/api-rest/src/main/{{language}}/{{packagePath}}/api/config/AuthorizationJwt.java"
+  },
+  "kotlin": {}
+}

--- a/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
+++ b/src/main/resources/entry-point/rest-mvc/build.gradle.mustache
@@ -10,4 +10,8 @@ dependencies {
     implementation 'io.springfox:springfox-boot-starter:{{springfoxVersion}}'
     implementation 'io.springfox:springfox-swagger-ui:{{springfoxVersion}}'
 {{/include-swagger}}
+{{#task-param-authorize}}
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+{{/task-param-authorize}}
 }


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Add authorization with jwt tokens for #350 issue.
This could work with multiple identity management providers. Local tests were made with Azure AD and Keycloak.
Please don't close the issue, I would like to implement this feature to webflux.

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
