### PR TITLE
feat(gradlew): Allow update version to java 21, generate gradle wrapper

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin' 
-          java-version: 11
+          java-version: 17
       - name: Set up NodeJS 18
         uses: actions/setup-node@v2
         with:
@@ -60,12 +60,12 @@ jobs:
       - name: Publish local
         if: steps.changes.outputs.templates == 'true'
         run: ./publish_plugin_local.sh
-      - name: Set up JDK 17
-        if: steps.changes.outputs.templates == 'true'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin' 
-          java-version: 17
+#      - name: Set up JDK 17
+#        if: steps.changes.outputs.templates == 'true'
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: 17
       # Generated code reactive
       - name: Generate reactive project to scan
         if: steps.changes.outputs.templates == 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ sonarqube {
         property "sonar.java-coveragePlugin", "jacoco"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/report.xml"
         property "sonar.test", "src/test/java"
-        property "sonar.exclusions", ".github/**,src/functionalTest/**,src/test/**/*Test.java,**/**models**,src/test/**/*Provider.java,**/**exceptions**,**/examples-ca/**,src/test/**/AnUpdate*.java"
+        property "sonar.exclusions", ".github/**,src/functionalTest/**,src/test/**/*Test.java,**/**models**,src/test/**/CAAssert.java,src/test/**/*Provider.java,**/**exceptions**,**/examples-ca/**,src/test/**/AnUpdate*.java"
         property "sonar.sourceEncoding", "UTF-8"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ sonarqube {
 }
 
 googleJavaFormat {
-    toolVersion = "1.9"
+    toolVersion = "1.7"
     exclude '**/examples-ca/**'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'java-gradle-plugin'
-    id 'org.sonarqube' version '4.0.0.2929'
-    id 'com.gradle.plugin-publish' version '1.2.0'
+    id 'org.sonarqube' version '4.4.1.3373'
+    id 'com.gradle.plugin-publish' version '1.2.1'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
@@ -169,27 +169,27 @@ if (project.hasProperty('signing.keyId')) { // publish as library in maven centr
 }
 
 dependencies {
-    api 'com.github.spullara.mustache.java:compiler:0.9.10'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.1'
+    api 'com.github.spullara.mustache.java:compiler:0.9.11'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1'
     implementation 'org.reflections:reflections:0.10.2'
 
     // swagger generators
-    implementation 'io.swagger.codegen.v3:swagger-codegen-generators:1.0.43'
+    implementation 'io.swagger.codegen.v3:swagger-codegen-generators:1.0.46'
     implementation 'com.googlecode.lambdaj:lambdaj:2.3.3'
-    implementation 'com.google.googlejavaformat:google-java-format:1.18.1'
+    implementation 'com.google.googlejavaformat:google-java-format:1.19.2'
 
-    api 'commons-io:commons-io:2.12.0'
+    api 'commons-io:commons-io:2.15.1'
     api gradleApi()
     testImplementation 'org.mockito:mockito-core:4.5.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation gradleTestKit()
 
-    compileOnly 'org.projectlombok:lombok:1.18.28'
-    annotationProcessor 'org.projectlombok:lombok:1.18.28'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 jacocoTestReport {
@@ -220,7 +220,7 @@ sonarqube {
 }
 
 googleJavaFormat {
-    toolVersion = "1.7"
+    toolVersion = "1.9"
     exclude '**/examples-ca/**'
 }
 
@@ -238,5 +238,5 @@ tasks.register('installGitHooks', Copy) {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '8.4'
+    gradleVersion = '8.5'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -30,11 +30,7 @@ public final class Constants {
   public static final String SPRINGDOC_OPENAPI_VERSION = "2.3.0";
   public static final String DEPENDENCY_CHECK_VERSION = "9.0.7";
   public static final String TOMCAT_EXCLUSION_KOTLIN =
-      "configurations {\n"
-          + "\tall {\n"
-          + "\t\texclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")\n"
-          + "\t}\n"
-          + "}";
+      "configurations {\n\tall {\n\t\texclude(group = \"org.springframework.boot\", module = \"spring-boot-starter-tomcat\")\n\t}\n}";
   public static final String TOMCAT_EXCLUSION =
       "implementation.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'";
   public static final String AWS_BOM =

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -9,7 +9,7 @@ public final class Constants {
   public static final String APP_SERVICE = "app-service";
   public static final String PATH_GRAPHQL = "/graphql";
   public static final String SECRETS_VERSION = "4.1.0";
-  public static final String SPRING_BOOT_VERSION = "3.2.0";
+  public static final String SPRING_BOOT_VERSION = "3.2.1";
   public static final String SONAR_VERSION = "4.4.1.3373";
   public static final String LOMBOK_VERSION = "1.18.30";
   public static final String JACOCO_VERSION = "0.8.10";

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -4,7 +4,10 @@ import static co.com.bancolombia.Constants.MainFiles.APPLICATION_PROPERTIES;
 import static co.com.bancolombia.Constants.MainFiles.KTS;
 import static co.com.bancolombia.task.GenerateStructureTask.Language.JAVA;
 import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Description;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Success;
 
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.adapters.RestService;
@@ -27,7 +30,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
@@ -350,15 +359,15 @@ public class ModuleBuilder {
   }
 
   public void runTask(String name) {
+    logger.lifecycle("Connecting to project to run task {}", name);
     try (ProjectConnection connection =
         GradleConnector.newConnector()
             .forProjectDirectory(getProject().getProjectDir())
             .connect()) {
-
-      connection.newBuild().forTasks(name).setStandardOutput(System.out).run();
-
+      logger.lifecycle("Connected! executing task {}", name);
+      connection.newBuild().forTasks(name).run();
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.warn("Error executing 'gradle wrapper', please run it you manually", e);
     }
   }
 

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -38,6 +38,8 @@ import lombok.SneakyThrows;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
 
 public class ModuleBuilder {
   private static final String DEFINITION_FILES = "definition.json";
@@ -345,6 +347,19 @@ public class ModuleBuilder {
       loadLatestRelease();
     }
     return (Release) params.get(LATEST_RELEASE);
+  }
+
+  public void runTask(String name) {
+    try (ProjectConnection connection =
+        GradleConnector.newConnector()
+            .forProjectDirectory(getProject().getProjectDir())
+            .connect()) {
+
+      connection.newBuild().forTasks(name).setStandardOutput(System.out).run();
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   private void loadPackage() {

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpdateDependencies.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpdateDependencies.java
@@ -66,8 +66,7 @@ public class UpdateDependencies implements UpgradeAction {
   private boolean applyToFile(
       ModuleBuilder builder, List<String> files, DependencyRelease release) {
     boolean applied =
-        files
-            .parallelStream()
+        files.parallelStream()
             .map(file -> update(builder, release, file))
             .reduce(false, (current, itemApplied) -> current || itemApplied);
     if (applied) {

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpdateDependencies.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpdateDependencies.java
@@ -66,7 +66,8 @@ public class UpdateDependencies implements UpgradeAction {
   private boolean applyToFile(
       ModuleBuilder builder, List<String> files, DependencyRelease release) {
     boolean applied =
-        files.parallelStream()
+        files
+            .parallelStream()
             .map(file -> update(builder, release, file))
             .reduce(false, (current, itemApplied) -> current || itemApplied);
     if (applied) {

--- a/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
@@ -154,6 +154,7 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     }
 
     builder.persist();
+    builder.runTask("wrapper");
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
@@ -128,9 +128,8 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     builder.addParam("example", withExample == BooleanOption.TRUE);
     builder.addParam("language", language.name().toLowerCase());
     builder.addParam("javaVersion", javaVersion);
-    builder.addParam("java8", javaVersion == JavaVersion.VERSION_1_8);
-    builder.addParam("java11", javaVersion == JavaVersion.VERSION_11);
     builder.addParam("java17", javaVersion == JavaVersion.VERSION_17);
+    builder.addParam("java21", javaVersion == JavaVersion.VERSION_21);
 
     boolean exists = FileUtils.exists(builder.getProject().getProjectDir().getPath(), MAIN_GRADLE);
     if (exists && force == BooleanOption.FALSE) {
@@ -189,9 +188,7 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
   }
 
   public enum JavaVersion {
-    @Deprecated
-    VERSION_1_8,
-    VERSION_11,
-    VERSION_17
+    VERSION_17,
+    VERSION_21
   }
 }

--- a/src/main/resources/structure/deployment/dockerfile.mustache
+++ b/src/main/resources/structure/deployment/dockerfile.mustache
@@ -1,12 +1,9 @@
-{{#java8}}
-FROM adoptopenjdk/openjdk8-openj9:alpine-slim
-{{/java8}}
-{{#java11}}
-FROM adoptopenjdk/openjdk11-openj9:alpine-slim
-{{/java11}}
 {{#java17}}
-FROM amazoncorretto:17-alpine
+FROM eclipse-temurin:17-jdk-alpine
 {{/java17}}
+{{#java21}}
+FROM eclipse-temurin:21-jdk-alpine
+{{/java21}}
 VOLUME /tmp
 COPY *.jar {{projectName}}.jar
 ENV JAVA_OPTS=" -Xshareclasses:name=cacheapp,cacheDir=/cache,nonfatal -XX:+UseContainerSupport -XX:MaxRAMPercentage=70 -Djava.security.egd=file:/dev/./urandom"

--- a/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
@@ -92,6 +92,9 @@ public class GenerateStructureTaskTest {
     assertTrue(new File("build/unitTest/main.gradle").exists());
     assertTrue(new File("build/unitTest/settings.gradle").exists());
 
+    assertTrue(new File("build/unitTest/gradlew").exists());
+    assertTrue(new File("build/unitTest/gradle/wrapper/gradle-wrapper.properties").exists());
+
     assertTrue(new File("build/unitTest/infrastructure/driven-adapters/").exists());
     assertTrue(new File("build/unitTest/infrastructure/entry-points").exists());
     assertTrue(new File("build/unitTest/infrastructure/helpers").exists());

--- a/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
@@ -1,7 +1,9 @@
 package co.com.bancolombia.task;
 
+import static co.com.bancolombia.utils.CAAssert.assertFilesExistsInDir;
 import static co.com.bancolombia.utils.FileUtilsTest.deleteStructure;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import co.com.bancolombia.Constants.BooleanOption;
 import co.com.bancolombia.exceptions.CleanException;
@@ -18,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class GenerateStructureTaskTest {
-  public static final String DIR = "build/unitTest/";
+  public static final String DIR = "build/unitTestCa/";
   private GenerateStructureTask task;
 
   @Before
@@ -26,7 +28,7 @@ public class GenerateStructureTaskTest {
     deleteStructure(Path.of(DIR));
     Project project =
         ProjectBuilder.builder()
-            .withProjectDir(new File("build/unitTest/"))
+            .withProjectDir(new File(DIR))
             .withGradleUserHomeDir(new File(DIR))
             .build();
     project.getTasks().create("test", GenerateStructureTask.class);
@@ -85,54 +87,32 @@ public class GenerateStructureTaskTest {
     // Act
     task.execute();
     // Assert
-    assertTrue(new File("build/unitTest/README.md").exists());
-    assertTrue(new File("build/unitTest/.gitignore").exists());
-    assertTrue(new File("build/unitTest/build.gradle").exists());
-    assertTrue(new File("build/unitTest/lombok.config").exists());
-    assertTrue(new File("build/unitTest/main.gradle").exists());
-    assertTrue(new File("build/unitTest/settings.gradle").exists());
-
-    assertTrue(new File("build/unitTest/gradlew").exists());
-    assertTrue(new File("build/unitTest/gradle/wrapper/gradle-wrapper.properties").exists());
-
-    assertTrue(new File("build/unitTest/infrastructure/driven-adapters/").exists());
-    assertTrue(new File("build/unitTest/infrastructure/entry-points").exists());
-    assertTrue(new File("build/unitTest/infrastructure/helpers").exists());
-
-    assertTrue(
-        new File("build/unitTest/domain/model/src/main/java/co/com/bancolombia/model").exists());
-    assertTrue(
-        new File("build/unitTest/domain/model/src/test/java/co/com/bancolombia/model").exists());
-    assertTrue(new File("build/unitTest/domain/model/build.gradle").exists());
-    assertTrue(
-        new File("build/unitTest/domain/usecase/src/main/java/co/com/bancolombia/usecase")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/domain/usecase/src/test/java/co/com/bancolombia/usecase")
-            .exists());
-    assertTrue(new File("build/unitTest/domain/usecase/build.gradle").exists());
-
-    assertTrue(new File("build/unitTest/applications/app-service/build.gradle").exists());
-    assertTrue(
-        new File(
-                "build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/MainApplication.java")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/UseCasesConfig.java")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/resources/application.yaml")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/resources/log4j2.properties")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/test/java/co/com/bancolombia")
-            .exists());
+    assertFilesExistsInDir(
+        DIR,
+        "README.md",
+        ".gitignore",
+        "build.gradle",
+        "lombok.config",
+        "main.gradle",
+        "settings.gradle",
+        "gradlew",
+        "gradle/wrapper/gradle-wrapper.properties",
+        "infrastructure/driven-adapters/",
+        "infrastructure/entry-points",
+        "infrastructure/helpers",
+        "domain/model/src/main/java/co/com/bancolombia/model",
+        "domain/model/src/test/java/co/com/bancolombia/model",
+        "domain/model/build.gradle",
+        "domain/usecase/src/main/java/co/com/bancolombia/usecase",
+        "domain/usecase/src/test/java/co/com/bancolombia/usecase",
+        "domain/usecase/build.gradle",
+        "applications/app-service/build.gradle",
+        "applications/app-service/src/main/java/co/com/bancolombia/MainApplication.java",
+        "applications/app-service/src/main/java/co/com/bancolombia/config/UseCasesConfig.java",
+        "applications/app-service/src/main/java/co/com/bancolombia/config",
+        "applications/app-service/src/main/resources/application.yaml",
+        "applications/app-service/src/main/resources/log4j2.properties",
+        "applications/app-service/src/test/java/co/com/bancolombia");
   }
 
   @Test
@@ -149,41 +129,30 @@ public class GenerateStructureTaskTest {
     // Act
     task.execute();
     // Assert
-    assertTrue(new File("build/unitTest/README.md").exists());
-    assertTrue(new File("build/unitTest/.gitignore").exists());
-    assertTrue(new File("build/unitTest/build.gradle").exists());
-    assertFalse(new File("build/unitTest/lombok.config").exists());
-    assertTrue(new File("build/unitTest/main.gradle").exists());
-    assertTrue(new File("build/unitTest/settings.gradle").exists());
-
-    assertTrue(new File("build/unitTest/infrastructure/driven-adapters/").exists());
-    assertTrue(new File("build/unitTest/infrastructure/entry-points").exists());
-    assertTrue(new File("build/unitTest/infrastructure/helpers").exists());
-
-    assertTrue(new File("build/unitTest/domain/model/src/main/java/test/model").exists());
-    assertTrue(new File("build/unitTest/domain/model/src/test/java/test/model").exists());
-    assertTrue(new File("build/unitTest/domain/model/build.gradle").exists());
-    assertTrue(new File("build/unitTest/domain/usecase/src/main/java/test/usecase").exists());
-    assertTrue(new File("build/unitTest/domain/usecase/src/test/java/test/usecase").exists());
-    assertTrue(new File("build/unitTest/domain/usecase/build.gradle").exists());
-
-    assertTrue(new File("build/unitTest/applications/app-service/build.gradle").exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/java/test/MainApplication.java")
-            .exists());
-    assertTrue(
-        new File(
-                "build/unitTest/applications/app-service/src/main/java/test/config/UseCasesConfig.java")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/java/test/config").exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/resources/application.yaml")
-            .exists());
-    assertTrue(
-        new File("build/unitTest/applications/app-service/src/main/resources/log4j2.properties")
-            .exists());
-    assertTrue(new File("build/unitTest/applications/app-service/src/test/java/test").exists());
+    assertFalse(new File(DIR + "lombok.config").exists());
+    assertFilesExistsInDir(
+        DIR,
+        "README.md",
+        ".gitignore",
+        "build.gradle",
+        "main.gradle",
+        "settings.gradle",
+        "infrastructure/driven-adapters/",
+        "infrastructure/entry-points",
+        "infrastructure/helpers",
+        "domain/model/src/main/java/test/model",
+        "domain/model/src/test/java/test/model",
+        "domain/model/build.gradle",
+        "domain/usecase/src/main/java/test/usecase",
+        "domain/usecase/src/test/java/test/usecase",
+        "domain/usecase/build.gradle",
+        "applications/app-service/build.gradle",
+        "applications/app-service/src/main/java/test/MainApplication.java",
+        "applications/app-service/src/main/java/test/config/UseCasesConfig.java",
+        "applications/app-service/src/main/java/test/config",
+        "applications/app-service/src/main/resources/application.yaml",
+        "applications/app-service/src/main/resources/log4j2.properties",
+        "applications/app-service/src/test/java/test");
   }
 
   @Test
@@ -193,9 +162,7 @@ public class GenerateStructureTaskTest {
     // Act
     task.execute();
     // Assert
-    assertTrue(new File("build/unitTest/build.gradle").exists());
-    assertTrue(new File("build/unitTest/gradle.properties").exists());
-    assertTrue(new File("build/unitTest/main.gradle").exists());
+    assertFilesExistsInDir(DIR, "build.gradle", "gradle.properties", "main.gradle");
   }
 
   @Test
@@ -206,10 +173,8 @@ public class GenerateStructureTaskTest {
     // Act
     task.execute();
     // Assert
-    assertTrue(new File("build/unitTest/build.gradle").exists());
-    assertTrue(new File("build/unitTest/gradle.properties").exists());
-    assertTrue(new File("build/unitTest/main.gradle").exists());
-    assertFalse(new File("build/unitTest/lombok.config").exists());
+    assertFilesExistsInDir(DIR, "build.gradle", "gradle.properties", "main.gradle");
+    assertFalse(new File(DIR + "lombok.config").exists());
   }
 
   @Test

--- a/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
@@ -142,7 +142,7 @@ public class GenerateStructureTaskTest {
     task.setStatusLombok(BooleanOption.FALSE);
     task.setMetrics(BooleanOption.FALSE);
     task.setForce(BooleanOption.FALSE);
-    task.setJavaVersion(JavaVersion.VERSION_11);
+    task.setJavaVersion(JavaVersion.VERSION_17);
     // Act
     task.execute();
     // Assert

--- a/src/test/java/co/com/bancolombia/utils/CAAssert.java
+++ b/src/test/java/co/com/bancolombia/utils/CAAssert.java
@@ -1,0 +1,21 @@
+package co.com.bancolombia.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.Assert;
+
+public class CAAssert extends Assert {
+  private CAAssert() {}
+
+  public static void assertFilesExists(String... files) {
+    for (String file : files) {
+      assertTrue("File: " + file + " not exists", Files.exists(Path.of(file)));
+    }
+  }
+
+  public static void assertFilesExistsInDir(String dir, String... files) {
+    assertFilesExists(
+        Arrays.stream(files).map(file -> dir + file).toList().toArray(new String[files.length]));
+  }
+}

--- a/src/test/java/co/com/bancolombia/utils/CAAssert.java
+++ b/src/test/java/co/com/bancolombia/utils/CAAssert.java
@@ -3,6 +3,7 @@ package co.com.bancolombia.utils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 
 public class CAAssert extends Assert {
@@ -16,6 +17,9 @@ public class CAAssert extends Assert {
 
   public static void assertFilesExistsInDir(String dir, String... files) {
     assertFilesExists(
-        Arrays.stream(files).map(file -> dir + file).toList().toArray(new String[files.length]));
+        Arrays.stream(files)
+            .map(file -> dir + file)
+            .collect(Collectors.toList())
+            .toArray(new String[files.length]));
   }
 }


### PR DESCRIPTION
## Description
- Add java 21 support closes #397 
- Generate gradle wrapper after structure generation

## Category
- [x] Feature
- [ ] Fix

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
