### PR TITLE
fix(sonar): exclude dependency and skip compile from sonar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.2.1'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
+    id 'org.owasp.dependencycheck' version '9.0.9'
 }
 
 ext {
@@ -183,7 +184,9 @@ dependencies {
     implementation 'org.reflections:reflections:0.10.2'
 
     // swagger generators
-    implementation 'io.swagger.codegen.v3:swagger-codegen-generators:1.0.46'
+    implementation ('io.swagger.codegen.v3:swagger-codegen-generators:1.0.46') {
+        exclude group: 'net.sf.jopt-simple', module: 'jopt-simple'
+    }
     implementation 'com.googlecode.lambdaj:lambdaj:2.3.3'
     implementation 'com.google.googlejavaformat:google-java-format:1.19.2'
 
@@ -229,6 +232,11 @@ sonar {
 googleJavaFormat {
     toolVersion = "1.7"
     exclude '**/examples-ca/**'
+}
+
+dependencyCheck {
+    format = 'JSON'
+    failOnError = false
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 package=co.com.bancolombia
 systemProp.version=3.13.0
 simulateRest=true
+systemProp.sonar.gradle.skipCompile=true

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M01D19SonarSkipCompile.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M01D19SonarSkipCompile.java
@@ -1,0 +1,30 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.GRADLE_PROPERTIES;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpdateUtils;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import lombok.SneakyThrows;
+
+public class UpgradeY2024M01D19SonarSkipCompile implements UpgradeAction {
+  public static final String SKIP_COMPILE = "systemProp.sonar.gradle.skipCompile";
+  public static final String SKIP_COMPILE_VALUE = "\nsystemProp.sonar.gradle.skipCompile=true";
+
+  @Override
+  @SneakyThrows
+  public boolean up(ModuleBuilder builder) {
+    return UpdateUtils.appendIfNotContains(
+        builder, GRADLE_PROPERTIES, SKIP_COMPILE, SKIP_COMPILE_VALUE);
+  }
+
+  @Override
+  public String name() {
+    return "3.13.0->3.13.1";
+  }
+
+  @Override
+  public String description() {
+    return "Add skipCompile for sonar";
+  }
+}

--- a/src/main/resources/structure/root/gradle.properties.mustache
+++ b/src/main/resources/structure/root/gradle.properties.mustache
@@ -5,6 +5,7 @@ lombok={{lombok}}
 metrics={{metrics}}
 language={{language}}
 org.gradle.parallel=true
+systemProp.sonar.gradle.skipCompile=true
 {{#example}}
 example=true
 {{/example}}

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M01D19SonarSkipCompileTest.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M01D19SonarSkipCompileTest.java
@@ -1,0 +1,62 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.GRADLE_PROPERTIES;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import co.com.bancolombia.utils.FileUtils;
+import com.github.mustachejava.resolver.DefaultResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpgradeY2024M01D19SonarSkipCompileTest {
+
+  @Mock private Project project;
+  @Mock private Logger logger;
+
+  private ModuleBuilder builder;
+  private UpgradeAction updater;
+
+  @Before
+  public void setup() throws IOException {
+    when(project.getName()).thenReturn("UtilsTest");
+    when(project.getLogger()).thenReturn(logger);
+    when(project.getProjectDir()).thenReturn(Files.createTempDirectory("sample").toFile());
+
+    builder = spy(new ModuleBuilder(project));
+    updater = new UpgradeY2024M01D19SonarSkipCompile();
+
+    assertNotNull(updater.name());
+    assertNotNull(updater.description());
+  }
+
+  @Test
+  public void shouldApplyUpdate() throws IOException {
+    DefaultResolver resolver = new DefaultResolver();
+    // Arrange
+    builder.addFile(
+        GRADLE_PROPERTIES,
+        FileUtils.getResourceAsString(resolver, "sonar-skip-compile/sonar-task-before.txt"));
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertTrue(applied);
+    verify(builder)
+        .addFile(
+            GRADLE_PROPERTIES,
+            FileUtils.getResourceAsString(resolver, "sonar-skip-compile/sonar-task-after.txt"));
+  }
+}

--- a/src/test/resources/sonar-skip-compile/sonar-task-after.txt
+++ b/src/test/resources/sonar-skip-compile/sonar-task-after.txt
@@ -1,0 +1,4 @@
+package=co.com.bancolombia
+systemProp.version=1.0.3-PREVIEW
+simulateRest=true
+systemProp.sonar.gradle.skipCompile=true

--- a/src/test/resources/sonar-skip-compile/sonar-task-before.txt
+++ b/src/test/resources/sonar-skip-compile/sonar-task-before.txt
@@ -1,0 +1,3 @@
+package=co.com.bancolombia
+systemProp.version=1.0.3-PREVIEW
+simulateRest=true


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Add systemProp.sonar.gradle.skipCompile=true to gradle properties

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- x ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
