### PR TITLE
feat(vault): Add vault secrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The **`generateDrivenAdapter | gda`** task will generate a module in Infrastruct
    | restconsumer                        | Rest Client Consumer                | --url [url] --from-swagger swagger.yaml            | &#9745; | &#9745; |
    | rsocket                             | RSocket Requester                   |                                                    | &#9745; | &#9745; |
    | s3                                  | AWS Simple Storage Service          |                                                    | &#9745; | &#9745; |
-   | secrets                             | Secrets Manager Bancolombia         |                                                    | &#9745; | &#9745; |
+   | secrets                             | Secrets Manager Bancolombia         | --secrets-backend [backend] <br> Valid options for backend are "aws_secrets_manager" (default) or "vault". | &#9745; | &#9745; |
    | sqs                                 | SQS message sender                  |                                                    | &#9745; | &#9745; |
 
    

--- a/examples-ca/example-redis/infrastructure/driven-adapters/redis/build.gradle
+++ b/examples-ca/example-redis/infrastructure/driven-adapters/redis/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':model')
 	implementation 'jakarta.persistence:jakarta.persistence-api'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'com.github.bancolombia:aws-secrets-manager-sync:4.1.0'
+    implementation 'com.github.bancolombia:aws-secrets-manager-sync:4.4.0'
     implementation 'org.reactivecommons.utils:object-mapper-api:0.1.0'
     testImplementation 'org.reactivecommons.utils:object-mapper:0.1.0'
 }

--- a/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
+++ b/src/functionalTest/java/co/com/bancolombia/PluginCleanFunctionalTest.java
@@ -275,43 +275,43 @@ public class PluginCleanFunctionalTest {
     assertTrue(new File(BUILD_FUNCTIONAL_TEST_INFRASTRUCTURE_HELPERS).exists());
 
     assertTrue(
-            new File("build/functionalTest/domain/model/src/main/java/co/com/bancolombia/model")
-                    .exists());
+        new File("build/functionalTest/domain/model/src/main/java/co/com/bancolombia/model")
+            .exists());
     assertTrue(
-            new File("build/functionalTest/domain/model/src/test/java/co/com/bancolombia/model")
-                    .exists());
+        new File("build/functionalTest/domain/model/src/test/java/co/com/bancolombia/model")
+            .exists());
     assertTrue(new File(BUILD_FUNCTIONAL_TEST_DOMAIN_MODEL_BUILD_GRADLE).exists());
     assertTrue(
-            new File("build/functionalTest/domain/usecase/src/main/java/co/com/bancolombia/usecase")
-                    .exists());
+        new File("build/functionalTest/domain/usecase/src/main/java/co/com/bancolombia/usecase")
+            .exists());
     assertTrue(
-            new File("build/functionalTest/domain/usecase/src/test/java/co/com/bancolombia/usecase")
-                    .exists());
+        new File("build/functionalTest/domain/usecase/src/test/java/co/com/bancolombia/usecase")
+            .exists());
     assertTrue(new File(BUILD_FUNCTIONAL_TEST_DOMAIN_USECASE_BUILD_GRADLE).exists());
 
     assertTrue(new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_BUILD_GRADLE).exists());
     assertTrue(
-            new File(
-                    "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/MainApplication.java")
-                    .exists());
+        new File(
+                "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/MainApplication.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/config/UseCasesConfig.java")
-                    .exists());
+        new File(
+                "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/config/UseCasesConfig.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/config")
-                    .exists());
+        new File(
+                "build/functionalTest/applications/app-service/src/main/java/co/com/bancolombia/config")
+            .exists());
     assertTrue(
-            new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_SRC_MAIN_RESOURCES_APPLICATION_YAML)
-                    .exists());
+        new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_SRC_MAIN_RESOURCES_APPLICATION_YAML)
+            .exists());
     assertTrue(
-            new File(
-                    BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_SRC_MAIN_RESOURCES_LOG_4_J_2_PROPERTIES)
-                    .exists());
+        new File(
+                BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_SRC_MAIN_RESOURCES_LOG_4_J_2_PROPERTIES)
+            .exists());
     assertTrue(
-            new File("build/functionalTest/applications/app-service/src/test/java/co/com/bancolombia")
-                    .exists());
+        new File("build/functionalTest/applications/app-service/src/test/java/co/com/bancolombia")
+            .exists());
 
     assertEquals(result.task(":" + task).getOutcome(), TaskOutcome.SUCCESS);
   }
@@ -719,8 +719,9 @@ public class PluginCleanFunctionalTest {
 
     try {
       runner.build();
-    } catch (Exception e){
-      Assert.assertTrue(e.getMessage().contains("This module is only available for reactive projects"));
+    } catch (Exception e) {
+      Assert.assertTrue(
+          e.getMessage().contains("This module is only available for reactive projects"));
     }
   }
 
@@ -734,11 +735,10 @@ public class PluginCleanFunctionalTest {
     runner.build();
 
     assertTrue(
-            FileUtils.readFileToString(
-                            new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_BUILD_GRADLE),
-                            StandardCharsets.UTF_8)
-                    .contains(
-                            "implementation 'com.github.bancolombia:vault-async:"));
+        FileUtils.readFileToString(
+                new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_BUILD_GRADLE),
+                StandardCharsets.UTF_8)
+            .contains("implementation 'com.github.bancolombia:vault-async:"));
   }
 
   @Test
@@ -751,11 +751,10 @@ public class PluginCleanFunctionalTest {
     runner.build();
 
     assertTrue(
-            FileUtils.readFileToString(
-                            new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_BUILD_GRADLE),
-                            StandardCharsets.UTF_8)
-                    .contains(
-                            "implementation 'com.github.bancolombia:aws-secrets-manager-async"));
+        FileUtils.readFileToString(
+                new File(BUILD_FUNCTIONAL_TEST_APPLICATIONS_APP_SERVICE_BUILD_GRADLE),
+                StandardCharsets.UTF_8)
+            .contains("implementation 'com.github.bancolombia:aws-secrets-manager-async"));
   }
 
   @Test

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -7,12 +7,15 @@ import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
 
 import co.com.bancolombia.Constants;
+import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.exceptions.ParamNotFoundException;
 import co.com.bancolombia.exceptions.ValidationException;
+import co.com.bancolombia.factory.adapters.DrivenAdapterSecrets;
 import co.com.bancolombia.factory.validations.Validation;
 import co.com.bancolombia.models.FileModel;
 import co.com.bancolombia.models.Release;
 import co.com.bancolombia.models.TemplateDefinition;
+import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import co.com.bancolombia.utils.FileUpdater;
 import co.com.bancolombia.utils.FileUtils;
 import co.com.bancolombia.utils.Utils;
@@ -215,6 +218,22 @@ public class ModuleBuilder {
       return "VAULT";
     } else {
       return "NONE";
+    }
+  }
+
+  public void setUpSecretsInAdapter() throws CleanException, IOException {
+    boolean includeSecrets = Boolean.TRUE.equals(getBooleanParam("include-secret"));
+    if (!includeSecrets) {
+      return;
+    }
+    String secretsBackend = getSecretsBackendEnabled();
+    if (secretsBackend.equals("NONE")) {
+      new DrivenAdapterSecrets().buildModule(this);
+      // when new secrets backend is added, the default is aws
+      addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+    } else {
+      addParam("include-awssecrets", "AWS_SECRETS_MANAGER".equalsIgnoreCase(secretsBackend));
+      addParam("include-vaultsecrets", "VAULT".equalsIgnoreCase(secretsBackend));
     }
   }
 

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -1,5 +1,11 @@
 package co.com.bancolombia.factory;
 
+import static co.com.bancolombia.Constants.MainFiles.APPLICATION_PROPERTIES;
+import static co.com.bancolombia.Constants.MainFiles.KTS;
+import static co.com.bancolombia.task.GenerateStructureTask.Language.JAVA;
+import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.ParamNotFoundException;
 import co.com.bancolombia.exceptions.ValidationException;
@@ -18,15 +24,6 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.github.mustachejava.resolver.DefaultResolver;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.SneakyThrows;
-import org.gradle.api.Project;
-import org.gradle.api.logging.Logger;
-import org.gradle.internal.logging.text.StyledTextOutput;
-import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ProjectConnection;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -38,12 +35,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static co.com.bancolombia.Constants.MainFiles.APPLICATION_PROPERTIES;
-import static co.com.bancolombia.Constants.MainFiles.KTS;
-import static co.com.bancolombia.task.GenerateStructureTask.Language.JAVA;
-import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
 
 public class ModuleBuilder {
   private static final String DEFINITION_FILES = "definition.json";
@@ -210,15 +209,11 @@ public class ModuleBuilder {
     if (isKotlin()) {
       fileName += ".kts";
     }
-    if (!findExpressions(fileName,
-            "com.github.bancolombia:aws-secrets").isEmpty()) {
+    if (!findExpressions(fileName, "com.github.bancolombia:aws-secrets").isEmpty()) {
       return "AWS_SECRETS_MANAGER";
-    }
-    else if (!findExpressions(fileName,
-            "com.github.bancolombia:vault").isEmpty()) {
+    } else if (!findExpressions(fileName, "com.github.bancolombia:vault").isEmpty()) {
       return "VAULT";
-    }
-    else {
+    } else {
       return "NONE";
     }
   }

--- a/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
+++ b/src/main/java/co/com/bancolombia/factory/ModuleBuilder.java
@@ -1,14 +1,5 @@
 package co.com.bancolombia.factory;
 
-import static co.com.bancolombia.Constants.MainFiles.APPLICATION_PROPERTIES;
-import static co.com.bancolombia.Constants.MainFiles.KTS;
-import static co.com.bancolombia.task.GenerateStructureTask.Language.JAVA;
-import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.Description;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.Header;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal;
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.Success;
-
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.ParamNotFoundException;
 import co.com.bancolombia.exceptions.ValidationException;
@@ -27,23 +18,6 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.github.mustachejava.resolver.DefaultResolver;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.MatchResult;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -52,6 +26,24 @@ import org.gradle.api.logging.Logger;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static co.com.bancolombia.Constants.MainFiles.APPLICATION_PROPERTIES;
+import static co.com.bancolombia.Constants.MainFiles.KTS;
+import static co.com.bancolombia.task.GenerateStructureTask.Language.JAVA;
+import static co.com.bancolombia.task.GenerateStructureTask.Language.KOTLIN;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
 
 public class ModuleBuilder {
   private static final String DEFINITION_FILES = "definition.json";
@@ -211,6 +203,24 @@ public class ModuleBuilder {
         .map(s -> s.replace("'", ""))
         .map(s -> s.replace("\"", ""))
         .collect(Collectors.toSet());
+  }
+
+  public String getSecretsBackendEnabled() {
+    String fileName = "applications/app-service/build.gradle";
+    if (isKotlin()) {
+      fileName += ".kts";
+    }
+    if (!findExpressions(fileName,
+            "com.github.bancolombia:aws-secrets").isEmpty()) {
+      return "AWS_SECRETS_MANAGER";
+    }
+    else if (!findExpressions(fileName,
+            "com.github.bancolombia:vault").isEmpty()) {
+      return "VAULT";
+    }
+    else {
+      return "NONE";
+    }
   }
 
   public void appendDependencyToModule(String module, String dependency) throws IOException {

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
@@ -1,15 +1,14 @@
 package co.com.bancolombia.factory.adapters;
 
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
 import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
-
 import java.io.IOException;
-
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
 
 public class DrivenAdapterJPA implements ModuleFactory {
   @Override
@@ -17,16 +16,19 @@ public class DrivenAdapterJPA implements ModuleFactory {
 
     if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
       DrivenAdapterSecrets.SecretsBackend secretsBackend =
-              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
       if (secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-          new DrivenAdapterSecrets().buildModule(builder);
-          //when new secrets backend is added, the default is aws
-          builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+        new DrivenAdapterSecrets().buildModule(builder);
+        // when new secrets backend is added, the default is aws
+        builder.addParam(
+            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
       } else {
-        builder.addParam("include-awssecrets",
-                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
-        builder.addParam("include-vaultsecrets",
-                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+        builder.addParam(
+            "include-awssecrets",
+            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+        builder.addParam(
+            "include-vaultsecrets",
+            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
       }
     }
 
@@ -46,5 +48,4 @@ public class DrivenAdapterJPA implements ModuleFactory {
 
     new ObjectMapperFactory().buildModule(builder);
   }
-
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
@@ -1,17 +1,35 @@
 package co.com.bancolombia.factory.adapters;
 
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
-
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
+import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
+
 import java.io.IOException;
+
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
 
 public class DrivenAdapterJPA implements ModuleFactory {
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+
+    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
+      DrivenAdapterSecrets.SecretsBackend secretsBackend =
+              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+      if (secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
+          new DrivenAdapterSecrets().buildModule(builder);
+          //when new secrets backend is added, the default is aws
+          builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+      } else {
+        builder.addParam("include-awssecrets",
+                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+        builder.addParam("include-vaultsecrets",
+                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+      }
+    }
+
     builder.setupFromTemplate("driven-adapter/jpa-repository");
     builder.appendToSettings("jpa-repository", "infrastructure/driven-adapters");
     builder
@@ -25,9 +43,8 @@ public class DrivenAdapterJPA implements ModuleFactory {
         .put("databasePlatform", "org.hibernate.dialect.H2Dialect");
     String dependency = buildImplementationFromProject(builder.isKotlin(), ":jpa-repository");
     builder.appendDependencyToModule(APP_SERVICE, dependency);
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      new DrivenAdapterSecrets().buildModule(builder);
-    }
+
     new ObjectMapperFactory().buildModule(builder);
   }
+
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterJPA.java
@@ -7,30 +7,13 @@ import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
-import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import java.io.IOException;
 
 public class DrivenAdapterJPA implements ModuleFactory {
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
 
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      DrivenAdapterSecrets.SecretsBackend secretsBackend =
-          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
-      if (secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-        new DrivenAdapterSecrets().buildModule(builder);
-        // when new secrets backend is added, the default is aws
-        builder.addParam(
-            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
-      } else {
-        builder.addParam(
-            "include-awssecrets",
-            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
-        builder.addParam(
-            "include-vaultsecrets",
-            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
-      }
-    }
+    builder.setUpSecretsInAdapter();
 
     builder.setupFromTemplate("driven-adapter/jpa-repository");
     builder.appendToSettings("jpa-repository", "infrastructure/driven-adapters");

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
@@ -1,19 +1,38 @@
 package co.com.bancolombia.factory.adapters;
 
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
-
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
-import java.io.IOException;
+import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
 
 public class DrivenAdapterMongoDB implements ModuleFactory {
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
     Logger logger = builder.getProject().getLogger();
+
+    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
+      DrivenAdapterSecrets.SecretsBackend secretsBackend =
+              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+      if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
+        builder.addParam("include-awssecrets",
+                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+        builder.addParam("include-vaultsecrets",
+                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+      } else {
+        new DrivenAdapterSecrets().buildModule(builder);
+        //when new secrets backend is added, the default is aws
+        builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+      }
+      logger.lifecycle("Adding secret dependency");
+    }
+
     if (Boolean.TRUE.equals(builder.isReactive())) {
       logger.lifecycle("Generating for reactive project");
       builder.setupFromTemplate("driven-adapter/mongo-reactive");
@@ -21,13 +40,12 @@ public class DrivenAdapterMongoDB implements ModuleFactory {
       logger.lifecycle("Generating for imperative project");
       builder.setupFromTemplate("driven-adapter/mongo-repository");
     }
+
     builder.appendToSettings("mongo-repository", "infrastructure/driven-adapters");
     builder.appendToProperties("spring.data.mongodb").put("uri", "mongodb://localhost:27017/test");
     String dependency = buildImplementationFromProject(builder.isKotlin(), ":mongo-repository");
     builder.appendDependencyToModule(APP_SERVICE, dependency);
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      new DrivenAdapterSecrets().buildModule(builder);
-    }
+
     new ObjectMapperFactory().buildModule(builder);
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
@@ -1,16 +1,15 @@
 package co.com.bancolombia.factory.adapters;
 
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
 import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
-import org.gradle.api.logging.Logger;
-
 import java.io.IOException;
-
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+import org.gradle.api.logging.Logger;
 
 public class DrivenAdapterMongoDB implements ModuleFactory {
   @Override
@@ -19,16 +18,19 @@ public class DrivenAdapterMongoDB implements ModuleFactory {
 
     if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
       DrivenAdapterSecrets.SecretsBackend secretsBackend =
-              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
       if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-        builder.addParam("include-awssecrets",
-                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
-        builder.addParam("include-vaultsecrets",
-                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+        builder.addParam(
+            "include-awssecrets",
+            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+        builder.addParam(
+            "include-vaultsecrets",
+            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
       } else {
         new DrivenAdapterSecrets().buildModule(builder);
-        //when new secrets backend is added, the default is aws
-        builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+        // when new secrets backend is added, the default is aws
+        builder.addParam(
+            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
       }
       logger.lifecycle("Adding secret dependency");
     }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterMongoDB.java
@@ -7,7 +7,6 @@ import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
-import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import java.io.IOException;
 import org.gradle.api.logging.Logger;
 
@@ -16,24 +15,7 @@ public class DrivenAdapterMongoDB implements ModuleFactory {
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
     Logger logger = builder.getProject().getLogger();
 
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      DrivenAdapterSecrets.SecretsBackend secretsBackend =
-          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
-      if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-        builder.addParam(
-            "include-awssecrets",
-            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
-        builder.addParam(
-            "include-vaultsecrets",
-            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
-      } else {
-        new DrivenAdapterSecrets().buildModule(builder);
-        // when new secrets backend is added, the default is aws
-        builder.addParam(
-            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
-      }
-      logger.lifecycle("Adding secret dependency");
-    }
+    builder.setUpSecretsInAdapter();
 
     if (Boolean.TRUE.equals(builder.isReactive())) {
       logger.lifecycle("Generating for reactive project");

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -1,15 +1,17 @@
 package co.com.bancolombia.factory.adapters;
 
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
-
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
-import java.io.IOException;
+import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
 
 public class DrivenAdapterRedis implements ModuleFactory {
   public static final String PARAM_MODE = "task-param-mode";
@@ -24,6 +26,22 @@ public class DrivenAdapterRedis implements ModuleFactory {
     Logger logger = builder.getProject().getLogger();
     String typePath = getPathType(builder.isReactive());
     String modePath = getPathMode((Mode) builder.getParam(PARAM_MODE));
+
+    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
+      DrivenAdapterSecrets.SecretsBackend secretsBackend =
+              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+      if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
+        builder.addParam("include-vaultsecrets",
+                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+        builder.addParam("include-awssecrets",
+                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+      } else {
+        new DrivenAdapterSecrets().buildModule(builder);
+        //when new secrets backend is added, the default is aws
+        builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+      }
+    }
+
     logger.lifecycle("Generating {} in {} mode", typePath, modePath);
     builder.setupFromTemplate("driven-adapter/" + typePath + "/" + modePath);
     builder.appendToSettings("redis", "infrastructure/driven-adapters");
@@ -34,9 +52,7 @@ public class DrivenAdapterRedis implements ModuleFactory {
     }
     String dependency = buildImplementationFromProject(builder.isKotlin(), ":redis");
     builder.appendDependencyToModule(APP_SERVICE, dependency);
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      new DrivenAdapterSecrets().buildModule(builder);
-    }
+
     new ObjectMapperFactory().buildModule(builder);
   }
 

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -1,17 +1,16 @@
 package co.com.bancolombia.factory.adapters;
 
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
 import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
-import org.gradle.api.logging.Logger;
-
 import java.io.IOException;
-
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+import org.gradle.api.logging.Logger;
 
 public class DrivenAdapterRedis implements ModuleFactory {
   public static final String PARAM_MODE = "task-param-mode";
@@ -29,16 +28,19 @@ public class DrivenAdapterRedis implements ModuleFactory {
 
     if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
       DrivenAdapterSecrets.SecretsBackend secretsBackend =
-              DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
+          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
       if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-        builder.addParam("include-vaultsecrets",
-                DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
-        builder.addParam("include-awssecrets",
-                DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
+        builder.addParam(
+            "include-vaultsecrets",
+            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
+        builder.addParam(
+            "include-awssecrets",
+            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
       } else {
         new DrivenAdapterSecrets().buildModule(builder);
-        //when new secrets backend is added, the default is aws
-        builder.addParam("include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+        // when new secrets backend is added, the default is aws
+        builder.addParam(
+            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
       }
     }
 

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterRedis.java
@@ -8,7 +8,6 @@ import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.ObjectMapperFactory;
-import co.com.bancolombia.task.AbstractCleanArchitectureDefaultTask;
 import java.io.IOException;
 import org.gradle.api.logging.Logger;
 
@@ -26,23 +25,7 @@ public class DrivenAdapterRedis implements ModuleFactory {
     String typePath = getPathType(builder.isReactive());
     String modePath = getPathMode((Mode) builder.getParam(PARAM_MODE));
 
-    if (Boolean.TRUE.equals(builder.getBooleanParam("include-secret"))) {
-      DrivenAdapterSecrets.SecretsBackend secretsBackend =
-          DrivenAdapterSecrets.SecretsBackend.valueOf(builder.getSecretsBackendEnabled());
-      if (!secretsBackend.equals(DrivenAdapterSecrets.SecretsBackend.NONE)) {
-        builder.addParam(
-            "include-vaultsecrets",
-            DrivenAdapterSecrets.SecretsBackend.VAULT.equals(secretsBackend));
-        builder.addParam(
-            "include-awssecrets",
-            DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER.equals(secretsBackend));
-      } else {
-        new DrivenAdapterSecrets().buildModule(builder);
-        // when new secrets backend is added, the default is aws
-        builder.addParam(
-            "include-awssecrets", AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
-      }
-    }
+    builder.setUpSecretsInAdapter();
 
     logger.lifecycle("Generating {} in {} mode", typePath, modePath);
     builder.setupFromTemplate("driven-adapter/" + typePath + "/" + modePath);

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterSecrets.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterSecrets.java
@@ -1,35 +1,61 @@
 package co.com.bancolombia.factory.adapters;
 
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementation;
-
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.GenericModule;
-import java.io.IOException;
 import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementation;
 
 public class DrivenAdapterSecrets implements ModuleFactory {
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
     Logger logger = builder.getProject().getLogger();
+
     String secretLibrary = "";
-    if (Boolean.TRUE.equals(builder.isReactive())) {
-      secretLibrary = "aws-secrets-manager-async";
-      builder.setupFromTemplate("driven-adapter/secrets-reactive");
+    SecretsBackend secretsBackend = (SecretsBackend) builder.getParam("secrets-backend");
+    if (secretsBackend == null || secretsBackend.equals(SecretsBackend.AWS_SECRETS_MANAGER)) {
+      if (Boolean.TRUE.equals(builder.isReactive())) {
+        secretLibrary = "aws-secrets-manager-async";
+        builder.setupFromTemplate("driven-adapter/secrets-reactive");
+      } else {
+        secretLibrary = "aws-secrets-manager-sync";
+        builder.setupFromTemplate("driven-adapter/secrets");
+      }
+      logger.lifecycle("Generating mode for aws secrets");
+      builder.appendToProperties("aws").put("region", "us-east-1").put("secretName", "my-secret");
+      GenericModule.addAwsBom(builder);
     } else {
-      secretLibrary = "aws-secrets-manager-sync";
-      builder.setupFromTemplate("driven-adapter/secrets");
+      if (Boolean.TRUE.equals(builder.isReactive())) {
+        secretLibrary = "vault-async";
+        builder.setupFromTemplate("driven-adapter/secrets-vault-reactive");
+      } else {
+        secretLibrary = "vault-sync";
+        builder.setupFromTemplate("driven-adapter/secrets-vault");
+      }
+      builder.appendToProperties("vault")
+              .put("host", "localhost")
+              .put("port", 8200)
+              .put("roleId", "<set your roleId>")
+              .put("secretId", "<set your secretId>")
+              .put("secretName", "my-secret");
+      logger.lifecycle("Generating mode for vault secrets");
     }
-    logger.lifecycle("Generating  mode");
-    GenericModule.addAwsBom(builder);
     String dependency =
         buildImplementation(
             builder.isKotlin(),
             "com.github.bancolombia:" + secretLibrary + ":" + Constants.SECRETS_VERSION);
     builder.appendDependencyToModule(APP_SERVICE, dependency);
-    builder.appendToProperties("aws").put("region", "us-east-1").put("secretName", "my-secret");
+  }
+
+  public enum SecretsBackend {
+    AWS_SECRETS_MANAGER,
+    VAULT,
+    NONE
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterSecrets.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterSecrets.java
@@ -1,16 +1,15 @@
 package co.com.bancolombia.factory.adapters;
 
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementation;
+
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.ModuleFactory;
 import co.com.bancolombia.factory.commons.GenericModule;
-import org.gradle.api.logging.Logger;
-
 import java.io.IOException;
-
-import static co.com.bancolombia.Constants.APP_SERVICE;
-import static co.com.bancolombia.utils.Utils.buildImplementation;
+import org.gradle.api.logging.Logger;
 
 public class DrivenAdapterSecrets implements ModuleFactory {
   @Override
@@ -38,12 +37,13 @@ public class DrivenAdapterSecrets implements ModuleFactory {
         secretLibrary = "vault-sync";
         builder.setupFromTemplate("driven-adapter/secrets-vault");
       }
-      builder.appendToProperties("vault")
-              .put("host", "localhost")
-              .put("port", 8200)
-              .put("roleId", "<set your roleId>")
-              .put("secretId", "<set your secretId>")
-              .put("secretName", "my-secret");
+      builder
+          .appendToProperties("vault")
+          .put("host", "localhost")
+          .put("port", 8200)
+          .put("roleId", "<set your roleId>")
+          .put("secretId", "<set your secretId>")
+          .put("secretName", "my-secret");
       logger.lifecycle("Generating mode for vault secrets");
     }
     String dependency =

--- a/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
@@ -2,6 +2,7 @@ package co.com.bancolombia.task;
 
 import co.com.bancolombia.factory.adapters.DrivenAdapterBinStash;
 import co.com.bancolombia.factory.adapters.DrivenAdapterRedis;
+import co.com.bancolombia.factory.adapters.DrivenAdapterSecrets;
 import co.com.bancolombia.task.annotations.CATask;
 import java.util.Arrays;
 import java.util.List;
@@ -15,6 +16,8 @@ import org.gradle.api.tasks.options.OptionValues;
 public class GenerateDrivenAdapterTask extends AbstractResolvableTypeTask {
   private String url = "http://localhost:8080";
   private String swaggerFile = null;
+  private DrivenAdapterSecrets.SecretsBackend secretsBackend = DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER;
+
   private DrivenAdapterRedis.Mode mode = DrivenAdapterRedis.Mode.TEMPLATE;
   private DrivenAdapterBinStash.CacheMode cacheMode = DrivenAdapterBinStash.CacheMode.LOCAL;
 
@@ -61,6 +64,11 @@ public class GenerateDrivenAdapterTask extends AbstractResolvableTypeTask {
     this.swaggerFile = swaggerFile;
   }
 
+  @Option(option = "secrets-backend", description = "Set secrets backend")
+  public void setSecretsBackend(DrivenAdapterSecrets.SecretsBackend secretsBackend) {
+    this.secretsBackend = secretsBackend;
+  }
+
   @Override
   protected void prepareParams() {
     builder.addParam("task-param-cache-mode", cacheMode);
@@ -69,6 +77,7 @@ public class GenerateDrivenAdapterTask extends AbstractResolvableTypeTask {
     builder.addParam(DrivenAdapterRedis.PARAM_MODE, mode);
     builder.addParam("task-param-url", url);
     builder.addParam("swagger-file", swaggerFile);
+    builder.addParam("secrets-backend", secretsBackend);
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateDrivenAdapterTask.java
@@ -16,7 +16,8 @@ import org.gradle.api.tasks.options.OptionValues;
 public class GenerateDrivenAdapterTask extends AbstractResolvableTypeTask {
   private String url = "http://localhost:8080";
   private String swaggerFile = null;
-  private DrivenAdapterSecrets.SecretsBackend secretsBackend = DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER;
+  private DrivenAdapterSecrets.SecretsBackend secretsBackend =
+      DrivenAdapterSecrets.SecretsBackend.AWS_SECRETS_MANAGER;
 
   private DrivenAdapterRedis.Mode mode = DrivenAdapterRedis.Mode.TEMPLATE;
   private DrivenAdapterBinStash.CacheMode cacheMode = DrivenAdapterBinStash.CacheMode.LOCAL;

--- a/src/main/resources/driven-adapter/jpa-repository/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/jpa-repository/build.gradle.kts.mustache
@@ -1,6 +1,13 @@
 dependencies {
     implementation(project(":model"))
 
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 

--- a/src/main/resources/driven-adapter/jpa-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/jpa-repository/build.gradle.mustache
@@ -1,6 +1,13 @@
 dependencies {
     implementation project(':model')
+
+    {{#include-awssecrets}}
     implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}'
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation 'com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}'
+    {{/include-vaultsecrets}}
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 

--- a/src/main/resources/driven-adapter/mongo-reactive/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/mongo-reactive/build.gradle.kts.mustache
@@ -4,6 +4,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-async:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-async:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     runtimeOnly("de.flapdoodle.embed:de.flapdoodle.embed.mongo") // TODO: remove this dependency to connect to real database
     testImplementation("org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 }

--- a/src/main/resources/driven-adapter/mongo-reactive/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/mongo-reactive/build.gradle.mustache
@@ -1,7 +1,13 @@
 dependencies {
     implementation project(':model')
 
-    implementation 'com.github.bancolombia:aws-secrets-manager-async:4.0.0'
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-async:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-async:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 

--- a/src/main/resources/driven-adapter/mongo-repository/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/mongo-repository/build.gradle.kts.mustache
@@ -4,6 +4,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     runtimeOnly("de.flapdoodle.embed:de.flapdoodle.embed.mongo") // TODO: remove this dependency to connect to real database
     testImplementation("org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 }

--- a/src/main/resources/driven-adapter/mongo-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/mongo-repository/build.gradle.mustache
@@ -4,6 +4,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     {{^example}}
     runtimeOnly 'de.flapdoodle.embed:de.flapdoodle.embed.mongo' // TODO: remove this dependency to connect to real database
     {{/example}}

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.kts.mustache
@@ -2,7 +2,14 @@ dependencies {
     implementation(project(":model"))
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
     implementation("com.fasterxml.jackson.core:jackson-databind")
+
+    {{#include-awssecrets}}
     implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 
     testImplementation("org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}")

--- a/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis-reactive/redis-template/build.gradle.mustache
@@ -2,9 +2,14 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    {{#include-secret}}
-    implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}'
-    {{/include-secret}}
+
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}'

--- a/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.kts.mustache
@@ -1,7 +1,14 @@
 dependencies {
     implementation(project(":model"))
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    {{#include-awssecrets}}
     implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 
     testImplementation("org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}")

--- a/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-repository/build.gradle.mustache
@@ -2,9 +2,15 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'jakarta.persistence:jakarta.persistence-api' // TODO: Check if it's still necessary
-    {{#include-secret}}
-    implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}'
-    {{/include-secret}}
+
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
+
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}'

--- a/src/main/resources/driven-adapter/redis/redis-template/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/build.gradle.kts.mustache
@@ -2,7 +2,15 @@ dependencies {
     implementation(project(":model"))
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("com.fasterxml.jackson.core:jackson-databind")
+
+    {{#include-awssecrets}}
     implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
+
     implementation("org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}")
 
     testImplementation("org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}")

--- a/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/redis/redis-template/build.gradle.mustache
@@ -2,9 +2,14 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    {{#include-secret}}
-    implementation 'com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}'
-    {{/include-secret}}
+
+    {{#include-awssecrets}}
+    implementation("com.github.bancolombia:aws-secrets-manager-sync:{{SECRETS_VERSION}}")
+    {{/include-awssecrets}}
+    {{#include-vaultsecrets}}
+    implementation("com.github.bancolombia:vault-sync:{{SECRETS_VERSION}}")
+    {{/include-vaultsecrets}}
+
     implementation 'org.reactivecommons.utils:object-mapper-api:{{REACTIVE_COMMONS_MAPPER_VERSION}}'
 
     testImplementation 'org.reactivecommons.utils:object-mapper:{{REACTIVE_COMMONS_MAPPER_VERSION}}'

--- a/src/main/resources/driven-adapter/secrets-vault-reactive/definition.json
+++ b/src/main/resources/driven-adapter/secrets-vault-reactive/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [],
+  "files": {},
+  "java": {
+    "driven-adapter/secrets-vault-reactive/secrets-config.java.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.java"
+  },
+  "kotlin": {
+    "driven-adapter/secrets-vault-reactive/secrets-config.kt.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.kt"
+  }
+}

--- a/src/main/resources/driven-adapter/secrets-vault-reactive/secrets-config.java.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault-reactive/secrets-config.java.mustache
@@ -1,0 +1,31 @@
+package {{package}}.config;
+
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import co.com.bancolombia.secretsmanager.connector.VaultSecretManagerConfigurator;
+import co.com.bancolombia.secretsmanager.vault.config.VaultSecretsManagerProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecretsConfig {
+
+  @Bean
+  public GenericManagerAsync getSecretManager(@Value("${vault.host:localhost}") String host,
+                                              @Value("${vault.port:8200}") int port) throws SecretException {
+          VaultSecretManagerConfigurator configurator = VaultSecretManagerConfigurator.builder()
+                  .withProperties(VaultSecretsManagerProperties.builder()
+                          .host(host)
+                          .port(port)
+                          .ssl(false)
+                          //.roleId("<my role id for auth with vault>")
+                          //.secretId("my secret id  for auth with vault>")
+                          .token("<my token>")  // or if you already have a token
+                          .build()
+                  )
+                  .build();
+          return configurator.getVaultClient();
+  }
+
+}

--- a/src/main/resources/driven-adapter/secrets-vault-reactive/secrets-config.kt.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault-reactive/secrets-config.kt.mustache
@@ -1,0 +1,30 @@
+package {{package}}.config
+
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import co.com.bancolombia.secretsmanager.connector.VaultSecretManagerConfigurator;
+import co.com.bancolombia.secretsmanager.vault.config.VaultSecretsManagerProperties;
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class SecretsConfig {
+
+  @Bean
+  open fun getSecretManager(@Value("\${vault.host}") host: String,
+                            @Value("\${vault.port}") port: int): GenericManagerAsync {
+          val configurator = VaultSecretManagerConfigurator.builder()
+                  .withProperties(VaultSecretsManagerProperties.builder()
+                          .host(host)
+                          .port(port)
+                          .ssl(false)
+                          //.roleId("<my role id for auth with vault>")
+                          //.secretId("my secret id  for auth with vault>")
+                          .token("<my token>")  // or if you already have a token
+                          .build()
+                  )
+                  .build();
+          return configurator.getVaultClient();
+  }
+}

--- a/src/main/resources/driven-adapter/secrets-vault/definition.json
+++ b/src/main/resources/driven-adapter/secrets-vault/definition.json
@@ -1,0 +1,10 @@
+{
+  "folders": [],
+  "files": {},
+  "java": {
+    "driven-adapter/secrets/secrets-config.java.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.java"
+  },
+  "kotlin": {
+    "driven-adapter/secrets/secrets-config.kt.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.kt"
+  }
+}

--- a/src/main/resources/driven-adapter/secrets-vault/definition.json
+++ b/src/main/resources/driven-adapter/secrets-vault/definition.json
@@ -2,9 +2,9 @@
   "folders": [],
   "files": {},
   "java": {
-    "driven-adapter/secrets/secrets-config.java.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.java"
+    "driven-adapter/secrets-vault/secrets-config.java.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.java"
   },
   "kotlin": {
-    "driven-adapter/secrets/secrets-config.kt.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.kt"
+    "driven-adapter/secrets-vault/secrets-config.kt.mustache": "applications/app-service/src/main/{{language}}/{{packagePath}}/config/SecretsConfig.kt"
   }
 }

--- a/src/main/resources/driven-adapter/secrets-vault/secrets-config.java.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault/secrets-config.java.mustache
@@ -1,0 +1,36 @@
+package {{package}}.config;
+
+import co.com.bancolombia.secretsmanager.api.GenericManager;
+import co.com.bancolombia.secretsmanager.vaultsync.connector.VaultSecretManagerConfigurator;
+import co.com.bancolombia.secretsmanager.vault.config.VaultSecretsManagerProperties;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecretsConfig {
+
+{{^include-secret}}
+  @Bean
+  public Object getSecret(@Value("${vault.secretName}") String secretName, GenericManager connector) throws SecretException {
+    return connector.getSecret(secretName, Object.class); // TODO Change the Object class for Secret model
+  }
+{{/include-secret}}
+
+  @Bean
+  public GenericManager getSecretManager(@Value("${vault.host:localhost}") String host,
+                                         @Value("${vault.port:8200}") int port) throws SecretException {
+      VaultSecretManagerConfigurator configurator = VaultSecretManagerConfigurator.builder()
+              .withProperties(VaultSecretsManagerProperties.builder()
+                      .host(host)
+                      .port(port)
+                      //.roleId("<my role id for auth with vault>")
+                      //.secretId("my secret id  for auth with vault>")
+                      .token("<my token>")  // or if you already have a token
+                      .build()
+              )
+              .build();
+      return configurator.getVaultClient();
+  }
+}

--- a/src/main/resources/driven-adapter/secrets-vault/secrets-config.java.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault/secrets-config.java.mustache
@@ -11,13 +11,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SecretsConfig {
 
-{{^include-secret}}
-  @Bean
-  public Object getSecret(@Value("${vault.secretName}") String secretName, GenericManager connector) throws SecretException {
-    return connector.getSecret(secretName, Object.class); // TODO Change the Object class for Secret model
-  }
-{{/include-secret}}
-
   @Bean
   public GenericManager getSecretManager(@Value("${vault.host:localhost}") String host,
                                          @Value("${vault.port:8200}") int port) throws SecretException {

--- a/src/main/resources/driven-adapter/secrets-vault/secrets-config.kt.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault/secrets-config.kt.mustache
@@ -11,20 +11,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 open class SecretsConfig {
 
-{{^include-secret}}
-    @Bean
-    @Throws(SecretException::class)
-    open fun getSecret(
-        @Value("\${vault.secretName}") secretName: String?,
-        connector: GenericManager
-    ): Any? {
-        return connector.getSecret(
-            secretName,
-            Any::class.java
-        ) // TODO Change the Object class for Secret model
-    }
-{{/include-secret}}
-
    @Bean
    open fun getSecretManager(@Value("\${vault.host}") host: String,
                             @Value("\${vault.port}") port: int): GenericManagerAsync {

--- a/src/main/resources/driven-adapter/secrets-vault/secrets-config.kt.mustache
+++ b/src/main/resources/driven-adapter/secrets-vault/secrets-config.kt.mustache
@@ -1,0 +1,45 @@
+package {{package}}.config
+
+import co.com.bancolombia.secretsmanager.api.GenericManager
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException
+import co.com.bancolombia.secretsmanager.vaultsync.connector.VaultSecretManagerConfigurator;
+import co.com.bancolombia.secretsmanager.vault.config.VaultSecretsManagerProperties;
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class SecretsConfig {
+
+{{^include-secret}}
+    @Bean
+    @Throws(SecretException::class)
+    open fun getSecret(
+        @Value("\${vault.secretName}") secretName: String?,
+        connector: GenericManager
+    ): Any? {
+        return connector.getSecret(
+            secretName,
+            Any::class.java
+        ) // TODO Change the Object class for Secret model
+    }
+{{/include-secret}}
+
+   @Bean
+   open fun getSecretManager(@Value("\${vault.host}") host: String,
+                            @Value("\${vault.port}") port: int): GenericManagerAsync {
+          val configurator = VaultSecretManagerConfigurator.builder()
+                  .withProperties(VaultSecretsManagerProperties.builder()
+                          .host(host)
+                          .port(port)
+                          .ssl(false)
+                          //.roleId("<my role id for auth with vault>")
+                          //.secretId("my secret id  for auth with vault>")
+                          .token("<my token>")  // or if you already have a token
+                          .build()
+                  )
+                  .build();
+          return configurator.getVaultClient();
+   }
+}
+

--- a/src/main/resources/structure/root/build.gradle.kts.mustache
+++ b/src/main/resources/structure/root/build.gradle.kts.mustache
@@ -22,7 +22,7 @@ java {
     sourceCompatibility = JavaVersion.{{javaVersion}}
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     kotlinOptions {
         freeCompilerArgs += "-Xjsr305=strict"
         jvmTarget = JavaVersion.{{javaVersion}}.toString()

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -8,6 +8,7 @@ import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
 import co.com.bancolombia.exceptions.ValidationException;
 import co.com.bancolombia.factory.adapters.DrivenAdapterRedis;
+import co.com.bancolombia.factory.adapters.DrivenAdapterSecrets;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -15,8 +16,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
-
-import co.com.bancolombia.factory.adapters.DrivenAdapterSecrets;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -109,14 +108,14 @@ public class GenerateDrivenAdapterTaskTest {
     task.execute();
     // Assert
     assertTrue(
-            new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
-                    .exists());
+        new File(
+                "build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
+            .exists());
     assertFalse(
-            FileUtils.readFileToString(
-                            new File("build/unitTest/applications/app-service/build.gradle"),
-                            StandardCharsets.UTF_8)
-                    .contains(
-                            "implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
+        FileUtils.readFileToString(
+                new File("build/unitTest/applications/app-service/build.gradle"),
+                StandardCharsets.UTF_8)
+            .contains("implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
   }
 
   @Test
@@ -127,15 +126,15 @@ public class GenerateDrivenAdapterTaskTest {
     task.execute();
     // Assert
     assertTrue(
-            new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
-                    .exists());
+        new File(
+                "build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
+            .exists());
 
     assertTrue(
-            FileUtils.readFileToString(
-                            new File("build/unitTest/applications/app-service/build.gradle"),
-                            StandardCharsets.UTF_8)
-                    .contains(
-                            "implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
+        FileUtils.readFileToString(
+                new File("build/unitTest/applications/app-service/build.gradle"),
+                StandardCharsets.UTF_8)
+            .contains("implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
   }
 
   @Test
@@ -252,28 +251,28 @@ public class GenerateDrivenAdapterTaskTest {
     task.execute();
     // Assert
     assertTrue(
-            new File("build/unitTest/infrastructure/driven-adapters/jpa-repository/build.gradle")
-                    .exists());
+        new File("build/unitTest/infrastructure/driven-adapters/jpa-repository/build.gradle")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepository.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepository.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepositoryAdapter.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepositoryAdapter.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/helper/AdapterOperations.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/helper/AdapterOperations.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/DBSecret.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/DBSecret.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/JpaConfig.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/JpaConfig.java")
+            .exists());
   }
 
   @Test
@@ -526,7 +525,7 @@ public class GenerateDrivenAdapterTaskTest {
 
   @Test
   public void generateDrivenAdapterRedisRepositoryForImperativeWithSecret()
-          throws IOException, CleanException {
+      throws IOException, CleanException {
     // Arrange
     setup(GenerateStructureTask.ProjectType.IMPERATIVE);
     task.setType("REDIS");
@@ -537,24 +536,24 @@ public class GenerateDrivenAdapterTaskTest {
     task.execute();
     // Assert
     assertTrue(
-            new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/RepositoryAdapterOperations.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/RepositoryAdapterOperations.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepository.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepository.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepositoryAdapter.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepositoryAdapter.java")
+            .exists());
   }
 
   @Test
   public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret()
-          throws IOException, CleanException {
+      throws IOException, CleanException {
     // Arrange
     setup(GenerateStructureTask.ProjectType.REACTIVE);
     task.setType("REDIS");
@@ -565,19 +564,19 @@ public class GenerateDrivenAdapterTaskTest {
     task.execute();
     // Assert
     assertTrue(
-            new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+        new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/helper/ReactiveTemplateAdapterOperations.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/helper/ReactiveTemplateAdapterOperations.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/ReactiveRedisTemplateAdapter.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/ReactiveRedisTemplateAdapter.java")
+            .exists());
     assertTrue(
-            new File(
-                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/config/RedisConfig.java")
-                    .exists());
+        new File(
+                "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/config/RedisConfig.java")
+            .exists());
   }
 
   @Test(expected = ValidationException.class)

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskTest.java
@@ -2,8 +2,7 @@ package co.com.bancolombia.task;
 
 import static co.com.bancolombia.Constants.APP_SERVICE;
 import static co.com.bancolombia.utils.FileUtilsTest.deleteStructure;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import co.com.bancolombia.Constants;
 import co.com.bancolombia.exceptions.CleanException;
@@ -13,8 +12,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+
+import co.com.bancolombia.factory.adapters.DrivenAdapterSecrets;
+import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
@@ -25,7 +28,7 @@ public class GenerateDrivenAdapterTaskTest {
 
   @Before
   public void init() throws IOException, CleanException {
-    setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+    setup(GenerateStructureTask.ProjectType.REACTIVE);
   }
 
   private void setup(GenerateStructureTask.ProjectType type) throws IOException, CleanException {
@@ -95,6 +98,44 @@ public class GenerateDrivenAdapterTaskTest {
         new File(
                 "build/unitTest/infrastructure/driven-adapters/my-driven-adapter/src/test/java/co/com/bancolombia/mydrivenadapter")
             .exists());
+  }
+
+  @Test
+  public void generateDrivenAdapterSecrets() throws IOException, CleanException {
+    // Arrange
+    task.setType("SECRETS");
+    task.setSecretsBackend(DrivenAdapterSecrets.SecretsBackend.VAULT);
+    // Act
+    task.execute();
+    // Assert
+    assertTrue(
+            new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
+                    .exists());
+    assertFalse(
+            FileUtils.readFileToString(
+                            new File("build/unitTest/applications/app-service/build.gradle"),
+                            StandardCharsets.UTF_8)
+                    .contains(
+                            "implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
+  }
+
+  @Test
+  public void generateDrivenAdapterSecretsWithDefault() throws IOException, CleanException {
+    // Arrange
+    task.setType("SECRETS");
+    // Act
+    task.execute();
+    // Assert
+    assertTrue(
+            new File("build/unitTest/applications/app-service/src/main/java/co/com/bancolombia/config/SecretsConfig.java")
+                    .exists());
+
+    assertTrue(
+            FileUtils.readFileToString(
+                            new File("build/unitTest/applications/app-service/build.gradle"),
+                            StandardCharsets.UTF_8)
+                    .contains(
+                            "implementation 'com.github.bancolombia:aws-secrets-manager-async:"));
   }
 
   @Test
@@ -200,6 +241,39 @@ public class GenerateDrivenAdapterTaskTest {
         new File(
                 "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/JpaConfig.java")
             .exists());
+  }
+
+  @Test
+  public void generateDrivenAdapterJPARepositoryWithSecrets() throws IOException, CleanException {
+    // Arrange
+    task.setType("JPA");
+    task.setSecret(AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+    // Act
+    task.execute();
+    // Assert
+    assertTrue(
+            new File("build/unitTest/infrastructure/driven-adapters/jpa-repository/build.gradle")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepository.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/JPARepositoryAdapter.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/helper/AdapterOperations.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/DBSecret.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/jpa-repository/src/main/java/co/com/bancolombia/jpa/config/JpaConfig.java")
+                    .exists());
   }
 
   @Test
@@ -448,6 +522,62 @@ public class GenerateDrivenAdapterTaskTest {
         new File(
                 "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepositoryAdapter.java")
             .exists());
+  }
+
+  @Test
+  public void generateDrivenAdapterRedisRepositoryForImperativeWithSecret()
+          throws IOException, CleanException {
+    // Arrange
+    setup(GenerateStructureTask.ProjectType.IMPERATIVE);
+    task.setType("REDIS");
+    task.setMode(DrivenAdapterRedis.Mode.REPOSITORY);
+    task.setSecret(AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+
+    // Act
+    task.execute();
+    // Assert
+    assertTrue(
+            new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/helper/RepositoryAdapterOperations.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepository.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/repository/RedisRepositoryAdapter.java")
+                    .exists());
+  }
+
+  @Test
+  public void generateDrivenAdapterRedisRepositoryForReactiveWithSecret()
+          throws IOException, CleanException {
+    // Arrange
+    setup(GenerateStructureTask.ProjectType.REACTIVE);
+    task.setType("REDIS");
+    task.setMode(DrivenAdapterRedis.Mode.TEMPLATE);
+    task.setSecret(AbstractCleanArchitectureDefaultTask.BooleanOption.TRUE);
+
+    // Act
+    task.execute();
+    // Assert
+    assertTrue(
+            new File("build/unitTest/infrastructure/driven-adapters/redis/build.gradle").exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/helper/ReactiveTemplateAdapterOperations.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/template/ReactiveRedisTemplateAdapter.java")
+                    .exists());
+    assertTrue(
+            new File(
+                    "build/unitTest/infrastructure/driven-adapters/redis/src/main/java/co/com/bancolombia/redis/config/RedisConfig.java")
+                    .exists());
   }
 
   @Test(expected = ValidationException.class)


### PR DESCRIPTION
## Description
Added support for Vault secrets backend.  This PR resolves #428 

## Category
- [x] Feature
- [ ] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
