### PR TITLE
feat(cognito): Add cognito token provider with cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,24 +303,25 @@ The **`generateDrivenAdapter | gda`** task will generate a module in Infrastruct
    gradle gda --type [drivenAdapterType]
    ```
 
-   | Reference for **drivenAdapterType** | Name                                | Additional Options                                 | Java    | Kotlin  |
-   |-------------------------------------|-------------------------------------|----------------------------------------------------|---------|---------|
-   | generic                             | Empty Driven Adapter                | --name [name]                                      | &#9745; | &#9745; |
-   | asynceventbus                       | Async Event Bus                     |                                                    | &#9745; | &#9745; |
-   | binstash                            | Bin Stash                           |                                                    | &#9745; | &#9745; |
-   | dynamodb                            | Dynamo DB adapter                   |                                                    | &#9745; | &#9745; |
-   | jpa                                 | JPA Repository                      | --secret [true-false]                              | &#9745; | &#9745; |
-   | kms                                 | AWS Key Management Service          |                                                    | &#9745; | &#9745; |
-   | ktor                                | HTTP client for kotlin              |                                                    | &#9744; | &#9745; |
-   | mongodb                             | Mongo Repository                    | --secret [true-false]                              | &#9745; | &#9745; |
-   | mq                                  | JMS MQ Client to send messages      |                                                    | &#9745; | &#9745; |
-   | r2dbc                               | R2dbc Postgresql Client             |                                                    | &#9745; | &#9745; |
-   | redis                               | Redis                               | --mode [template-repository] --secret [true-false] | &#9745; | &#9745; |
-   | restconsumer                        | Rest Client Consumer                | --url [url] --from-swagger swagger.yaml            | &#9745; | &#9745; |
-   | rsocket                             | RSocket Requester                   |                                                    | &#9745; | &#9745; |
-   | s3                                  | AWS Simple Storage Service          |                                                    | &#9745; | &#9745; |
-   | secrets                             | Secrets Manager Bancolombia         | --secrets-backend [backend] <br> Valid options for backend are "aws_secrets_manager" (default) or "vault". | &#9745; | &#9745; |
-   | sqs                                 | SQS message sender                  |                                                    | &#9745; | &#9745; |
+   | Reference for **drivenAdapterType** | Name                           | Additional Options                                 | Java    | Kotlin  |
+   |-------------------------------------|--------------------------------|----------------------------------------------------|---------|---------|
+   | generic                             | Empty Driven Adapter           | --name [name]                                      | &#9745; | &#9745; |
+   | asynceventbus                       | Async Event Bus                |                                                    | &#9745; | &#9745; |
+   | binstash                            | Bin Stash                      |                                                    | &#9745; | &#9745; |
+   | cognitotokenprovider                | Generador de token de cognito  |                                                    | &#9745; |         |
+   | dynamodb                            | Dynamo DB adapter              |                                                    | &#9745; | &#9745; |
+   | jpa                                 | JPA Repository                 | --secret [true-false]                              | &#9745; | &#9745; |
+   | kms                                 | AWS Key Management Service     |                                                    | &#9745; | &#9745; |
+   | ktor                                | HTTP client for kotlin         |                                                    | &#9744; | &#9745; |
+   | mongodb                             | Mongo Repository               | --secret [true-false]                              | &#9745; | &#9745; |
+   | mq                                  | JMS MQ Client to send messages |                                                    | &#9745; | &#9745; |
+   | r2dbc                               | R2dbc Postgresql Client        |                                                    | &#9745; | &#9745; |
+   | redis                               | Redis                          | --mode [template-repository] --secret [true-false] | &#9745; | &#9745; |
+   | restconsumer                        | Rest Client Consumer           | --url [url] --from-swagger swagger.yaml            | &#9745; | &#9745; |
+   | rsocket                             | RSocket Requester              |                                                    | &#9745; | &#9745; |
+   | s3                                  | AWS Simple Storage Service     |                                                    | &#9745; | &#9745; |
+   | secrets                             | Secrets Manager Bancolombia    | --secrets-backend [backend] <br> Valid options for backend are "aws_secrets_manager" (default) or "vault". | &#9745; | &#9745; |
+   | sqs                                 | SQS message sender             |                                                    | &#9745; | &#9745; |
 
    
    _**This task will generate something like that:**_

--- a/sh_generate_project.sh
+++ b/sh_generate_project.sh
@@ -25,7 +25,7 @@ gradle wrapper
 
 if [ $TYPE == "reactive" ]
 then
-  for adapter in "asynceventbus" "binstash" "dynamodb" "kms" "mongodb" "mq" "r2dbc" "redis" "restconsumer" "rsocket" "s3" "secrets" "sqs"
+  for adapter in "asynceventbus" "binstash" "cognitotokenprovider" "dynamodb" "kms" "mongodb" "mq" "r2dbc" "redis" "restconsumer" "rsocket" "s3" "secrets" "sqs"
   do
     ./gradlew gda --type $adapter
   done

--- a/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterCognitoTokenProvider.java
+++ b/src/main/java/co/com/bancolombia/factory/adapters/DrivenAdapterCognitoTokenProvider.java
@@ -1,0 +1,34 @@
+package co.com.bancolombia.factory.adapters;
+
+import static co.com.bancolombia.Constants.APP_SERVICE;
+import static co.com.bancolombia.utils.Utils.buildImplementationFromProject;
+
+import co.com.bancolombia.exceptions.CleanException;
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.ModuleFactory;
+import co.com.bancolombia.factory.validations.ReactiveTypeValidation;
+import java.io.IOException;
+import org.gradle.api.logging.Logger;
+
+public class DrivenAdapterCognitoTokenProvider implements ModuleFactory {
+
+  @Override
+  public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
+    Logger logger = builder.getProject().getLogger();
+    builder.runValidations(ReactiveTypeValidation.class);
+
+    logger.lifecycle("Generating cognito token provider for reactive project");
+    builder.setupFromTemplate("driven-adapter/cognito-token-provider/reactive");
+
+    builder
+        .appendToProperties("adapter.cognito")
+        .put("secret", "<cognito-credentials-secret-name>")
+        .put("timeout", 5000)
+        .put("endpoint", "https://<domain>.auth.<region>.amazoncognito.com/oauth2/token");
+
+    builder.appendToSettings("cognito-token-provider", "infrastructure/driven-adapters");
+    String dependency =
+        buildImplementationFromProject(builder.isKotlin(), ":cognito-token-provider");
+    builder.appendDependencyToModule(APP_SERVICE, dependency);
+  }
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/build.gradle.mustache
@@ -1,0 +1,9 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.github.bancolombia:secrets-manager-api:{{SECRETS_VERSION}}'
+
+    testImplementation 'com.squareup.okhttp3:okhttp:{{OKHTTP_VERSION}}'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:{{OKHTTP_VERSION}}'
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-credentials.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-credentials.java.mustache
@@ -1,0 +1,32 @@
+package {{package}}.cognito.model;
+
+{{#lombok}}
+import lombok.Data;
+
+@Data
+{{/lombok}}
+public class CognitoCredentials {
+    private String clientId;
+    private String clientSecret;
+    {{^lombok}}
+
+    public CognitoCredentials() {
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+    {{/lombok}}
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider-config.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider-config.java.mustache
@@ -1,0 +1,61 @@
+package {{package}}.cognito.config;
+
+import {{package}}.cognito.CognitoTokenProvider;
+import {{package}}.cognito.model.CognitoCredentials;
+import {{package}}.model.gateway.TokenProvider;
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@Configuration
+public class CognitoTokenProviderConfig {
+    @Bean
+    public TokenProvider cognitoTokenProvider(@Value("${adapter.cognito.endpoint}") String endpoint,
+                                              @Value("${adapter.cognito.timeout}") int timeout,
+                                              WebClient.Builder builder, Mono<CognitoCredentials> provider) {
+        WebClient client = getWebClientCognito(builder, endpoint, timeout);
+        return new CognitoTokenProvider(client, provider);
+    }
+
+    @Bean
+    public Mono<CognitoCredentials> cognitoCredentialsProvider(@Value("${adapter.cognito.secret}") String secret,
+                                                                GenericManagerAsync manager) throws SecretException {
+        return manager.getSecret(secret, CognitoCredentials.class);
+    }
+
+    private WebClient getWebClientCognito(WebClient.Builder builder, String endpoint, int timeout) {
+        return builder
+                .baseUrl(endpoint)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .clientConnector(getClientHttpConnector(timeout))
+                .build();
+    }
+
+    private ClientHttpConnector getClientHttpConnector(int timeout) {
+        /*
+        IF YO REQUIRE APPEND SSL CERTIFICATE SELF SIGNED: this should be in the default cacerts trustore
+        */
+        return new ReactorClientHttpConnector(HttpClient.create()
+                .compress(true)
+                .keepAlive(true)
+                .option(CONNECT_TIMEOUT_MILLIS, timeout)
+                .doOnConnected(connection -> {
+                    connection.addHandlerLast(new ReadTimeoutHandler(timeout, MILLISECONDS));
+                    connection.addHandlerLast(new WriteTimeoutHandler(timeout, MILLISECONDS));
+                }));
+    }
+
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider.java.mustache
@@ -1,0 +1,54 @@
+package {{package}}.cognito;
+
+import {{package}}.cognito.model.CognitoCredentials;
+import {{package}}.cognito.model.CognitoTokenResponse;
+import {{package}}.model.gateway.TokenProvider;
+{{#lombok}}
+import lombok.extern.log4j.Log4j2;
+{{/lombok}}
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.time.Duration;
+
+{{#lombok}}
+@Log4j2
+{{/lombok}}
+public class CognitoTokenProvider implements TokenProvider {
+{{^lombok}}
+    private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(CognitoTokenProvider.class);
+{{/lombok}}
+    public static final int COGNITO_RETRIES = 3;
+    private final Mono<String> cachedToken;
+
+    public CognitoTokenProvider(WebClient client, Mono<CognitoCredentials> credentialsProvider) {
+        this.cachedToken = credentialsProvider
+                .flatMap(credentials ->
+                        client.post()
+                                .body(BodyInserters.fromFormData("grant_type", "client_credentials")
+                                        .with("client_id", credentials.getClientId())
+                                        .with("client_secret", credentials.getClientSecret()))
+                                .retrieve()
+                                .onStatus(HttpStatusCode::isError, response -> response.bodyToMono(String.class)
+                                        .map(IOException::new))
+                                .bodyToMono(CognitoTokenResponse.class)
+                                .retry(COGNITO_RETRIES))
+                .doOnError(err -> log.warn("Error calling cognito", err))
+                .cache(this::cacheTime, error -> Duration.ZERO, () -> Duration.ZERO)
+                .map(CognitoTokenResponse::getAccessToken);
+        }
+
+    @Override
+    public Mono<String> getToken() {
+        return cachedToken;
+    }
+
+    private Duration cacheTime(CognitoTokenResponse token) {
+        log.info("Generated from cognito and expires in: {} seconds and will be refreshed in: {} seconds",
+                token.getExpiresIn(), token.getCacheTime());
+        return Duration.ofSeconds(token.getCacheTime());
+    }
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider.test.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-provider.test.java.mustache
@@ -1,0 +1,52 @@
+package {{package}}.cognito;
+
+import {{package}}.cognito.config.CognitoTokenProviderConfig;
+import {{package}}.cognito.model.CognitoCredentials;
+import co.com.bancolombia.secretsmanager.api.GenericManagerAsync;
+import co.com.bancolombia.secretsmanager.api.exceptions.SecretException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoTokenProviderTest {
+    @Mock
+    private GenericManagerAsync manager;
+    private MockWebServer server;
+    private CognitoTokenProvider provider;
+
+    @BeforeEach
+    void setup() throws SecretException {
+        CognitoTokenProviderConfig config = new CognitoTokenProviderConfig();
+        server = new MockWebServer();
+        String endpoint = server.url("/oauth2/token").toString();
+        when(manager.getSecret("secret", CognitoCredentials.class))
+                .thenReturn(Mono.just(new CognitoCredentials()));
+        Mono<CognitoCredentials> credentials = config.cognitoCredentialsProvider("secret", manager);
+        provider = (CognitoTokenProvider) config.cognitoTokenProvider(endpoint, 1000,
+                WebClient.builder(), credentials);
+    }
+
+    @Test
+    void shouldGetToken() {
+        // Arrange
+        String tokenResponse = "{\"access_token\":\"token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}";
+        server.enqueue(new MockResponse()
+                .setHeader("content-type", "application/json")
+                .setBody(tokenResponse));
+        // Act
+        StepVerifier.create(provider.getToken())
+                .expectNext("token")
+                .verifyComplete();
+    }
+
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-response.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/cognito-token-response.java.mustache
@@ -1,0 +1,50 @@
+package {{package}}.cognito.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+{{#lombok}}
+import lombok.Data;
+
+@Data
+{{/lombok}}
+public class CognitoTokenResponse {
+    public static final int FREE_REFRESH_SECONDS = 60; // 1 minute before expiration
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("expires_in")
+    private int expiresIn;
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    public int getCacheTime() {
+        return getExpiresIn() - FREE_REFRESH_SECONDS;
+    }
+    {{^lombok}}
+
+    public CognitoTokenResponse() {
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(int expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+    {{/lombok}}
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/definition.json
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/definition.json
@@ -1,0 +1,14 @@
+{
+  "folders": [],
+  "files": {},
+  "java": {
+    "driven-adapter/cognito-token-provider/reactive/build.gradle.mustache": "infrastructure/driven-adapters/cognito-token-provider/build.gradle",
+    "driven-adapter/cognito-token-provider/reactive/cognito-token-provider-config.java.mustache": "infrastructure/driven-adapters/cognito-token-provider/src/main/{{language}}/{{packagePath}}/cognito/config/CognitoTokenProviderConfig.java",
+    "driven-adapter/cognito-token-provider/reactive/cognito-token-provider.test.java.mustache": "infrastructure/driven-adapters/cognito-token-provider/src/test/{{language}}/{{packagePath}}/cognito/CognitoTokenProviderTest.java",
+    "driven-adapter/cognito-token-provider/reactive/cognito-token-provider.java.mustache": "infrastructure/driven-adapters/cognito-token-provider/src/main/{{language}}/{{packagePath}}/cognito/CognitoTokenProvider.java",
+    "driven-adapter/cognito-token-provider/reactive/cognito-credentials.java.mustache": "infrastructure/driven-adapters/cognito-token-provider/src/main/{{language}}/{{packagePath}}/cognito/model/CognitoCredentials.java",
+    "driven-adapter/cognito-token-provider/reactive/cognito-token-response.java.mustache": "infrastructure/driven-adapters/cognito-token-provider/src/main/{{language}}/{{packagePath}}/cognito/model/CognitoTokenResponse.java",
+    "driven-adapter/cognito-token-provider/reactive/token-provider.java.mustache": "domain/model/src/main/{{language}}/{{packagePath}}/model/gateway/TokenProvider.java"
+  },
+  "kotlin": {}
+}

--- a/src/main/resources/driven-adapter/cognito-token-provider/reactive/token-provider.java.mustache
+++ b/src/main/resources/driven-adapter/cognito-token-provider/reactive/token-provider.java.mustache
@@ -1,0 +1,7 @@
+package {{package}}.model.gateway;
+
+import reactor.core.publisher.Mono;
+
+public interface TokenProvider {
+    Mono<String> getToken();
+}

--- a/src/main/resources/driven-adapter/consumer-rest/reactive-rest-consumer/build.gradle.mustache
+++ b/src/main/resources/driven-adapter/consumer-rest/reactive-rest-consumer/build.gradle.mustache
@@ -9,7 +9,7 @@ dependencies {
     implementation 'io.micrometer:micrometer-core'
     {{/metrics}}
 
-    testImplementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
+    testImplementation 'com.squareup.okhttp3:okhttp:{{OKHTTP_VERSION}}'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:{{OKHTTP_VERSION}}'
 
 }

--- a/src/main/resources/driven-adapter/consumer-rest/rest-consumer/build.gradle.kts.mustache
+++ b/src/main/resources/driven-adapter/consumer-rest/rest-consumer/build.gradle.kts.mustache
@@ -1,6 +1,6 @@
 dependencies {
     implementation(project(":model"))
-    implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+    implementation("com.squareup.okhttp3:okhttp:{{OKHTTP_VERSION}}")
+    testImplementation("com.squareup.okhttp3:mockwebserver:{{OKHTTP_VERSION}}")
     implementation("com.fasterxml.jackson.core:jackson-databind")
 }

--- a/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskReactiveTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateDrivenAdapterTaskReactiveTest.java
@@ -281,4 +281,22 @@ class GenerateDrivenAdapterTaskReactiveTest {
         TEST_DIR + "/applications/app-service/build.gradle",
         "implementation 'com.github.bancolombia:aws-secrets-manager-async:");
   }
+
+  @Test
+  void generateDrivenAdapterCognitoTokenProvider() throws IOException, CleanException {
+    // Arrange
+    task.setType("COGNITOTOKENPROVIDER");
+    // Act
+    task.execute();
+    // Assert
+    assertFilesExistsInDir(
+        TEST_DIR + "/domain/model/",
+        "src/main/java/co/com/bancolombia/model/gateway/TokenProvider.java");
+    assertFilesExistsInDir(
+        TEST_DIR + "/infrastructure/driven-adapters/cognito-token-provider/",
+        "src/main/java/co/com/bancolombia/cognito/model/CognitoCredentials.java",
+        "src/main/java/co/com/bancolombia/cognito/model/CognitoTokenResponse.java",
+        "src/main/java/co/com/bancolombia/cognito/config/CognitoTokenProviderConfig.java",
+        "src/main/java/co/com/bancolombia/cognito/CognitoTokenProvider.java");
+  }
 }


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Add cognito token provider from credentials and define a default cache to reuse a token

## Category
- [x] Feature
- [ ] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [x] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
