### PR TITLE
feat: remove cobertura plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ If you run this task on an existing project it will override the `main.gradle`, 
 
    - **`name`** `= NameProject`: This parameter is going to specify the name of the project. `Default Value = cleanArchitecture`
 
-   - **`coverage`** `= <jacoco | cobertura>`: This parameter is going to specify the coverage tool for the project. `Default Value = jacoco`
    
    - **`lombok`** `= <true | false>`: Specify if you want to use this plugin  . `Default Value = true`
 
@@ -83,8 +82,8 @@ If you run this task on an existing project it will override the `main.gradle`, 
    - **`javaVersion`** `= <VERSION_17 | VERSION_21>`: Java version  . `Default Value = VERSION_17`
    
    ```shell
-   gradle cleanArchitecture --package=co.com.bancolombia --type=reactive --name=NameProject --coverage=jacoco --lombok=true
-   gradle ca --package=co.com.bancolombia --type=reactive --name=NameProject --coverage=jacoco --lombok=true
+   gradle cleanArchitecture --package=co.com.bancolombia --type=reactive --name=NameProject --lombok=true
+   gradle ca --package=co.com.bancolombia --type=reactive --name=NameProject --lombok=true
    ```
 
    **_The structure will look like this for java:_**

--- a/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
@@ -21,7 +21,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
   private static final String REACTIVE = "reactive";
   private String packageName = "co.com.bancolombia";
   private ProjectType type = ProjectType.REACTIVE;
-  private CoveragePlugin coverage = CoveragePlugin.JACOCO;
   private String name = "cleanArchitecture";
   private BooleanOption lombok = BooleanOption.TRUE;
   private BooleanOption metrics = BooleanOption.TRUE;
@@ -50,10 +49,7 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     this.name = projectName;
   }
 
-  @Option(option = "coverage", description = "Set project coverage plugin")
-  public void setCoveragePlugin(CoveragePlugin coverage) {
-    this.coverage = coverage;
-  }
+
 
   @Option(option = "lombok", description = "Switch the status of lombok in this project")
   public void setStatusLombok(BooleanOption lombok) {
@@ -85,10 +81,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     return Arrays.asList(ProjectType.values());
   }
 
-  @OptionValues("coverage")
-  public List<CoveragePlugin> getCoveragePlugins() {
-    return Arrays.asList(CoveragePlugin.values());
-  }
 
   @OptionValues("lombok")
   public List<BooleanOption> getLombokOptions() {
@@ -120,8 +112,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     builder.addParamPackage(packageName);
     builder.addParam("projectName", name);
     builder.addParam(REACTIVE, type == ProjectType.REACTIVE);
-    builder.addParam("jacoco", coverage == CoveragePlugin.JACOCO);
-    builder.addParam("cobertura", coverage == CoveragePlugin.COBERTURA);
     builder.addParam("lombok", lombok == BooleanOption.TRUE);
     builder.addParam("metrics", metrics == BooleanOption.TRUE);
     builder.addParam("example", withExample == BooleanOption.TRUE);
@@ -175,11 +165,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
   public enum ProjectType {
     REACTIVE,
     IMPERATIVE
-  }
-
-  public enum CoveragePlugin {
-    JACOCO,
-    COBERTURA
   }
 
   public enum Language {

--- a/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
+++ b/src/main/java/co/com/bancolombia/task/GenerateStructureTask.java
@@ -49,8 +49,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
     this.name = projectName;
   }
 
-
-
   @Option(option = "lombok", description = "Switch the status of lombok in this project")
   public void setStatusLombok(BooleanOption lombok) {
     this.lombok = lombok;
@@ -80,7 +78,6 @@ public class GenerateStructureTask extends AbstractCleanArchitectureDefaultTask 
   public List<ProjectType> getAvailableProjectTypes() {
     return Arrays.asList(ProjectType.values());
   }
-
 
   @OptionValues("lombok")
   public List<BooleanOption> getLombokOptions() {

--- a/src/main/resources/structure/root/build.gradle.kts.mustache
+++ b/src/main/resources/structure/root/build.gradle.kts.mustache
@@ -54,9 +54,7 @@ sonarqube {
 
 subprojects {
     apply(plugin = "kotlin")
-{{#jacoco}}
     apply(plugin = "jacoco")
-{{/jacoco }}
     apply(plugin = "io.spring.dependency-management")
     dependencies {
 {{#reactive}}
@@ -78,7 +76,6 @@ subprojects {
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
     }
-{{#jacoco}}
    project.tasks.test.get().finalizedBy(project.tasks.jacocoTestReport)
    project.tasks.jacocoTestReport {
        dependsOn(project.tasks.test)
@@ -89,10 +86,9 @@ subprojects {
            html.outputLocation = layout.buildDirectory.dir("reports/jacocoHtml")
        }
    }
-{{/jacoco }}
+
 }
 
-{{#jacoco}}
 jacoco {
     toolVersion = "{{JACOCO_VERSION}}"
     reportsDirectory = layout.buildDirectory.dir("reports")
@@ -114,4 +110,4 @@ tasks.withType<JacocoReport> {
         html.required = true
     }
 }
-{{/jacoco}}
+

--- a/src/main/resources/structure/root/build.gradle.mustache
+++ b/src/main/resources/structure/root/build.gradle.mustache
@@ -3,12 +3,7 @@ buildscript {
 		cleanArchitectureVersion = '{{PLUGIN_VERSION}}'
 		springBootVersion = '{{SPRING_BOOT_VERSION}}'
 		sonarVersion = '{{SONAR_VERSION}}'
-		{{#jacoco}}
 		jacocoVersion = '{{JACOCO_VERSION}}'
-		{{/jacoco}}
-		{{#cobertura}}
-		coberturaVersion = '{{COBERTURA_VERSION}}'
-		{{/cobertura}}
 		{{#lombok}}
         lombokVersion = '{{LOMBOK_VERSION}}'
         {{/lombok}}
@@ -35,12 +30,7 @@ plugins {
     {{/example}}
 	id 'org.springframework.boot' version "${springBootVersion}" apply false
 	id 'org.sonarqube' version "${sonarVersion}"
-	{{#jacoco}}
 	id 'jacoco'
-	{{/jacoco}}
-	{{#cobertura}}
-	id 'net.saliman.cobertura' version "${coberturaVersion}"
-	{{/cobertura}}
 }
 {{#example}}
 apply plugin: "co.com.bancolombia.cleanArchitecture"

--- a/src/main/resources/structure/root/main.gradle.mustache
+++ b/src/main/resources/structure/root/main.gradle.mustache
@@ -8,12 +8,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    {{#jacoco}}
     apply plugin: 'jacoco'
-    {{/jacoco}}
-    {{#cobertura}}
-    apply plugin: 'net.saliman.cobertura'
-    {{/cobertura}}
     apply plugin: 'io.spring.dependency-management'
 
     compileJava.dependsOn validateStructure
@@ -53,7 +48,6 @@ subprojects {
     }
     {{/reactive}}
 
-    {{#jacoco}}
     test.finalizedBy(project.tasks.jacocoTestReport)
 
     jacocoTestReport {
@@ -65,18 +59,9 @@ subprojects {
             html.setOutputLocation layout.buildDirectory.dir("reports/jacocoHtml")
         }
     }
-    {{/jacoco}}
-    {{#cobertura}}
-    test.finalizedBy(project.tasks.cobertura)
-
-    cobertura {
-        coverageFormats = [ 'xml', 'html' ]
-    }
-    {{/cobertura}}
 
 }
 
-{{#jacoco}}
 jacoco {
     toolVersion = "${jacocoVersion}"
     reportsDirectory.set(layout.buildDirectory.dir("reports"))
@@ -94,18 +79,6 @@ tasks.register('jacocoMergedReport', JacocoReport) {
         html.setRequired true
     }
 }
-{{/jacoco}}
-{{#cobertura}}
-def files = subprojects.collect { new File(it.projectDir, '/build/cobertura/cobertura.ser') }
-
-cobertura {
-    coverageFormats = ['xml', 'html']
-    coverageSourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
-    coverageMergeDatafiles = files
-}
-
-test.finalizedBy(project.tasks.cobertura)
-{{/cobertura}}
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs = [

--- a/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
@@ -47,14 +47,7 @@ class GenerateStructureTaskTest {
     assertEquals(Arrays.asList(GenerateStructureTask.ProjectType.values()), types);
   }
 
-  @Test
-  void shouldReturnCoveragePluginTypes() {
-    // Arrange
-    // Act
-    List<GenerateStructureTask.CoveragePlugin> types = task.getCoveragePlugins();
-    // Assert
-    assertEquals(Arrays.asList(GenerateStructureTask.CoveragePlugin.values()), types);
-  }
+
 
   @Test
   void shouldReturnMetricsOptions() {
@@ -116,46 +109,6 @@ class GenerateStructureTaskTest {
         "applications/app-service/src/test/java/co/com/bancolombia");
   }
 
-  @Test
-  void generateStructureReactiveWithCoberturaNoLombok() throws IOException, CleanException {
-    // Arrange
-    String dir = project.getProjectDir().getPath();
-    task.setPackage("test");
-    task.setName("projectTest");
-    task.setType(GenerateStructureTask.ProjectType.REACTIVE);
-    task.setCoveragePlugin(GenerateStructureTask.CoveragePlugin.COBERTURA);
-    task.setStatusLombok(AbstractCleanArchitectureDefaultTask.BooleanOption.FALSE);
-    task.setMetrics(AbstractCleanArchitectureDefaultTask.BooleanOption.FALSE);
-    task.setForce(AbstractCleanArchitectureDefaultTask.BooleanOption.FALSE);
-    task.setJavaVersion(JavaVersion.VERSION_17);
-    // Act
-    task.execute();
-    // Assert
-    assertFalse(new File(dir + "lombok.config").exists());
-    assertFilesExistsInDir(
-        dir,
-        "README.md",
-        ".gitignore",
-        "build.gradle",
-        "main.gradle",
-        "settings.gradle",
-        "infrastructure/driven-adapters/",
-        "infrastructure/entry-points",
-        "infrastructure/helpers",
-        "domain/model/src/main/java/test/model",
-        "domain/model/src/test/java/test/model",
-        "domain/model/build.gradle",
-        "domain/usecase/src/main/java/test/usecase",
-        "domain/usecase/src/test/java/test/usecase",
-        "domain/usecase/build.gradle",
-        "applications/app-service/build.gradle",
-        "applications/app-service/src/main/java/test/MainApplication.java",
-        "applications/app-service/src/main/java/test/config/UseCasesConfig.java",
-        "applications/app-service/src/main/java/test/config",
-        "applications/app-service/src/main/resources/application.yaml",
-        "applications/app-service/src/main/resources/log4j2.properties",
-        "applications/app-service/src/test/java/test");
-  }
 
   @Test
   void generateStructureOnExistingProject() throws IOException, CleanException {

--- a/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GenerateStructureTaskTest.java
@@ -47,8 +47,6 @@ class GenerateStructureTaskTest {
     assertEquals(Arrays.asList(GenerateStructureTask.ProjectType.values()), types);
   }
 
-
-
   @Test
   void shouldReturnMetricsOptions() {
     // Arrange
@@ -108,7 +106,6 @@ class GenerateStructureTaskTest {
         "applications/app-service/src/main/resources/log4j2.properties",
         "applications/app-service/src/test/java/co/com/bancolombia");
   }
-
 
   @Test
   void generateStructureOnExistingProject() throws IOException, CleanException {


### PR DESCRIPTION
the option to configure the cover tool is eliminated, it remains preset jacoco

## Description
<!--- Describe your changes in detail -->

## Category
- [x] Feature
- [ ] Fix
- [ ] Ci / Docs

## Checklist
- [ ] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
