### PR TITLE
fix(ci): Skip ci when automatic release push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,6 +10,7 @@ on:
       - master
 jobs:
   build:
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           push-branch: "master"
-          commit-message: 'upgrade version to ${{ env.RELEASE_VERSION }} version'
+          commit-message: 'upgrade version to ${{ env.RELEASE_VERSION }} version [skip ci]'
           force-add: "true"
           force-push: "true"
           files: CHANGELOG.md README.md gradle.properties src/main/java/co/com/bancolombia/Constants.java

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -12,6 +12,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -9,6 +9,7 @@ permissions:
   
 jobs:
   TruffleHog:
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Update release actions and conditions for automatic releases

## Category
- [ ] Feature
- [ ] Fix
- [x] Ci / Docs

## Checklist
- [ ] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [ ] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
