### PR TITLE
fix(mode): Enable mode selection to use updater in non clean architec…

### DIFF
--- a/src/main/java/co/com/bancolombia/PluginClean.java
+++ b/src/main/java/co/com/bancolombia/PluginClean.java
@@ -3,6 +3,7 @@ package co.com.bancolombia;
 import co.com.bancolombia.models.TaskModel;
 import co.com.bancolombia.task.ValidateStructureTask;
 import co.com.bancolombia.task.annotations.CATask;
+import co.com.bancolombia.utils.FileUtils;
 import co.com.bancolombia.utils.ReflectionUtils;
 import java.util.stream.Stream;
 import org.gradle.api.Action;
@@ -17,6 +18,19 @@ public class PluginClean implements Plugin<Project> {
   private CleanPluginExtension cleanPluginExtension;
 
   public void apply(Project project) {
+    boolean onlyUpdater = false;
+    try {
+      onlyUpdater = FileUtils.readBooleanProperty("onlyUpdater");
+    } catch (Exception e) {
+      project.getLogger().debug("Property onlyUpdater not found, using default value false", e);
+    }
+    if (onlyUpdater) {
+      TaskContainer taskContainer = project.getTasks();
+      initTasks()
+          .filter(t -> "it".equals(t.getShortcut()))
+          .forEach(task -> this.appendTask(taskContainer, task));
+      return;
+    }
     project.getPluginManager().apply("java");
     cleanPluginExtension =
         project.getExtensions().create("cleanPlugin", CleanPluginExtension.class);


### PR DESCRIPTION
…ture projects

Before submitting a pull request, please read
https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing

## Description
Add option to use it only as dependency updater

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing)
- [ ] Automated tests are written
- [ ] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adpater or entry-point, you should add it to `RADME.md` and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#upgradeaction)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://github.com/bancolombia/scaffold-clean-architecture/wiki/Contributing#analytics)
