### PR TITLE
fix(deps): Add junit-platform-launcher if not exists

### DIFF
--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M10D17AddPitest.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M10D17AddPitest.java
@@ -114,6 +114,13 @@ public class UpgradeY2024M10D17AddPitest implements UpgradeAction {
               partial =
                   UpdateUtils.insertAfterMatch(partial, "dependsOn test", "'pitest'", ", 'pitest'");
 
+              partial =
+                  UpdateUtils.insertAfterMatch(
+                      partial,
+                      "dependencies {",
+                      "junit-platform-launcher",
+                      "\n        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'");
+
               return UpdateUtils.insertBeforeMatch(
                   partial,
                   "tasks.named('wrapper')",

--- a/src/test/resources/pitest/main-after.txt
+++ b/src/test/resources/pitest/main-after.txt
@@ -16,12 +16,12 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_17
 
     dependencies {
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         implementation 'io.projectreactor:reactor-core'
         implementation 'io.projectreactor.addons:reactor-extra'
         testImplementation 'io.projectreactor:reactor-test'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'io.projectreactor.tools:blockhound-junit-platform:1.0.10.RELEASE'
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/src/test/resources/pitest/main-before.txt
+++ b/src/test/resources/pitest/main-before.txt
@@ -18,7 +18,6 @@ subprojects {
         testImplementation 'io.projectreactor:reactor-test'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'io.projectreactor.tools:blockhound-junit-platform:1.0.10.RELEASE'
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor "org.projectlombok:lombok:${lombokVersion}"


### PR DESCRIPTION
Before submitting a pull request, please read
https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing

## Description
Add testRuntimeOnly 'org.junit.platform:junit-platform-launcher' when not exists

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
