### PR TITLE
feat(gradle): add UpgradeAction for gradle 8.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.3.0'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'org.owasp.dependencycheck' version '10.0.4'
+    id 'org.owasp.dependencycheck' version '11.1.0'
 }
 
 ext {
@@ -175,16 +175,16 @@ if (project.hasProperty('signing.keyId')) { // publish as library in maven centr
 
 dependencies {
     api 'com.github.spullara.mustache.java:compiler:0.9.14'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.0'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.0'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.18.1'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.1'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.1'
     api 'commons-io:commons-io:2.17.0'
     api gradleApi()
 
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.1'
     implementation 'org.reflections:reflections:0.10.2'
     // swagger generators
-    implementation('io.swagger.codegen.v3:swagger-codegen-generators:1.0.53') {
+    implementation('io.swagger.codegen.v3:swagger-codegen-generators:1.0.54') {
         exclude group: 'net.sf.jopt-simple', module: 'jopt-simple'
     }
     constraints { // for previous swagger dependency
@@ -197,13 +197,13 @@ dependencies {
 
     testImplementation gradleTestKit()
     testImplementation 'org.mockito:mockito-junit-jupiter:5.14.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.3'
 
-    compileOnly 'org.projectlombok:lombok:1.18.34'
-    annotationProcessor 'org.projectlombok:lombok:1.18.34'
+    compileOnly 'org.projectlombok:lombok:1.18.36'
+    annotationProcessor 'org.projectlombok:lombok:1.18.36'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
@@ -261,7 +261,9 @@ tasks.register('copyPreCommit', Copy) {
 tasks.register('downloadCommitMessage') {
     def f = new File('.git/hooks/commit-msg.sample2')
     if (!f.exists()) {
-        new URL('https://raw.githubusercontent.com/hazcod/semantic-commit-hook/master/commit-msg').withInputStream { i -> f.withOutputStream { it << i } }
+        new URL('https://raw.githubusercontent.com/hazcod/semantic-commit-hook/master/commit-msg').withInputStream {
+            i -> f.withOutputStream { it << i }
+        }
     }
 }
 
@@ -281,7 +283,7 @@ tasks.register('installGitHooks') {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '8.10.2'
+    gradleVersion = '8.11'
 }
 
 tasks.register('ci-updater', JavaExec) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -32,7 +32,7 @@ public final class Constants {
   public static final String DEPENDENCY_CHECK_VERSION = "11.1.0";
   public static final String PITEST_VERSION = "1.15.0";
   // custom
-  public static final String GRADLE_WRAPPER_VERSION = "8.10.2";
+  public static final String GRADLE_WRAPPER_VERSION = "8.11";
 
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   public static class MainFiles {

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
@@ -8,17 +8,33 @@ import co.com.bancolombia.factory.upgrades.UpgradeAction;
 import lombok.SneakyThrows;
 
 public class UpgradeY2024M11D16Gradle implements UpgradeAction {
+  private static final String JAVA_BLOCK_CONFIG =
+      "java {\n        {{sourceCompatibilityLoaded}}\n    }";
 
   @Override
   @SneakyThrows
   public boolean up(ModuleBuilder builder) {
     return builder.updateFile(
         MAIN_GRADLE,
-        content ->
-            UpdateUtils.replace(
-                content,
-                "sourceCompatibility = JavaVersion.VERSION_17",
-                "\n\tjava {\n" + "\t\tsourceCompatibility = JavaVersion.VERSION_17\n" + "\t}"));
+        content -> {
+          String sourceCompatibilityLoaded =
+              builder
+                  .findExpressions(
+                      MAIN_GRADLE, "sourceCompatibility = JavaVersion.VERSION_(\\d{2})")
+                  .stream()
+                  .findFirst()
+                  .orElse(null);
+
+          if (sourceCompatibilityLoaded == null) {
+            sourceCompatibilityLoaded = "sourceCompatibility = JavaVersion.{{javaVersion}}";
+          }
+
+          return UpdateUtils.replace(
+              content,
+              sourceCompatibilityLoaded,
+              JAVA_BLOCK_CONFIG.replace(
+                  "{{sourceCompatibilityLoaded}}", sourceCompatibilityLoaded));
+        });
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
@@ -1,0 +1,33 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.MAIN_GRADLE;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpdateUtils;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import lombok.SneakyThrows;
+
+public class UpgradeY2024M11D16Gradle implements UpgradeAction {
+
+  @Override
+  @SneakyThrows
+  public boolean up(ModuleBuilder builder) {
+    return builder.updateFile(
+        MAIN_GRADLE,
+        content ->
+            UpdateUtils.replace(
+                content,
+                "sourceCompatibility = JavaVersion.VERSION_17",
+                "\n\tjava {\n" + "\t\tsourceCompatibility = JavaVersion.VERSION_17\n" + "\t}"));
+  }
+
+  @Override
+  public String name() {
+    return "3.18.2->3.18.3";
+  }
+
+  @Override
+  public String description() {
+    return "Add java { } configuration block, backed by JavaPluginExtension";
+  }
+}

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16GradleTest.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16GradleTest.java
@@ -1,0 +1,61 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.MAIN_GRADLE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import co.com.bancolombia.utils.FileUtils;
+import com.github.mustachejava.resolver.DefaultResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UpgradeY2024M11D16GradleTest {
+
+  @Mock private Project project;
+  @Mock private Logger logger;
+
+  private ModuleBuilder builder;
+  private UpgradeAction updater;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    when(project.getName()).thenReturn("UtilsTest");
+    when(project.getLogger()).thenReturn(logger);
+    when(project.getProjectDir()).thenReturn(Files.createTempDirectory("sample").toFile());
+
+    builder = spy(new ModuleBuilder(project));
+    updater = new UpgradeY2024M11D16Gradle();
+
+    assertNotNull(updater.name());
+    assertNotNull(updater.description());
+  }
+
+  @Test
+  void shouldApplyUpdate() throws IOException {
+    DefaultResolver resolver = new DefaultResolver();
+    // Arrange
+    builder.addFile(
+        MAIN_GRADLE, FileUtils.getResourceAsString(resolver, "gradle-8.11-sample/main-before.txt"));
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertTrue(applied);
+    verify(builder)
+        .addFile(
+            MAIN_GRADLE,
+            FileUtils.getResourceAsString(resolver, "gradle-8.11-sample/main-after.txt"));
+  }
+}

--- a/src/test/resources/gradle-8.11-sample/main-after.txt
+++ b/src/test/resources/gradle-8.11-sample/main-after.txt
@@ -15,7 +15,6 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     compileJava.dependsOn validateStructure
-
     java {
         sourceCompatibility = JavaVersion.VERSION_17
     }
@@ -52,7 +51,7 @@ subprojects {
     test.finalizedBy(project.tasks.jacocoTestReport)
 
     pitest {
-        targetClasses = ['co.com.luisgomez29.*']
+        targetClasses = ['your.package.*']
         excludedClasses = []
         excludedTestClasses = []
         pitestVersion = '1.16.1'
@@ -126,5 +125,5 @@ pitestReportAggregate {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '8.11'
+    gradleVersion = '8.10.2'
 }

--- a/src/test/resources/gradle-8.11-sample/main-after.txt
+++ b/src/test/resources/gradle-8.11-sample/main-after.txt
@@ -1,6 +1,4 @@
-{{#mutation}}
 apply plugin: 'info.solidsoft.pitest.aggregator'
-{{/mutation}}
 
 allprojects {
     repositories {
@@ -11,48 +9,38 @@ allprojects {
 }
 
 subprojects {
+    apply plugin: 'info.solidsoft.pitest'
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'io.spring.dependency-management'
-    {{#mutation}}
-    apply plugin: 'info.solidsoft.pitest'
-    {{/mutation}}
 
     compileJava.dependsOn validateStructure
 
     java {
-        sourceCompatibility = JavaVersion.{{javaVersion}}
+        sourceCompatibility = JavaVersion.VERSION_17
     }
-
-    {{#mutation}}
-    //build.dependsOn 'pitest'
-    {{/mutation}}
 
     test {
         useJUnitPlatform()
     }
 
     dependencies {
-        {{#reactive}}
+		implementation platform('software.amazon.awssdk:bom:2.29.15')
         implementation 'io.projectreactor:reactor-core'
         implementation 'io.projectreactor.addons:reactor-extra'
 
-        testImplementation 'io.projectreactor.tools:blockhound-junit-platform:{{BLOCK_HOUND_VERSION}}'
+        testImplementation 'io.projectreactor.tools:blockhound-junit-platform:1.0.10.RELEASE'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
         testImplementation 'io.projectreactor:reactor-test'
-        {{/reactive}}
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
-        {{#lombok}}
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
         testCompileOnly  "org.projectlombok:lombok:${lombokVersion}"
         testAnnotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
-        {{/lombok}}
         implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
     }
 
-    {{#reactive}}
     tasks.withType(Test).configureEach {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
             jvmArgs += [
@@ -60,21 +48,18 @@ subprojects {
             ]
         }
     }
-    {{/reactive}}
 
     test.finalizedBy(project.tasks.jacocoTestReport)
 
-    {{#mutation}}
     pitest {
-        targetClasses = ['{{package}}.*']
+        targetClasses = ['co.com.luisgomez29.*']
         excludedClasses = []
         excludedTestClasses = []
-        pitestVersion = '1.17.1'
+        pitestVersion = '1.16.1'
         verbose = true
         outputFormats = ['XML', 'HTML']
         threads = 8
         exportLineCoverage = true
-        useClasspathFile = true
         timestampedReports = false
         //mutators = ['STRONGER', 'DEFAULTS']
         fileExtensionsToFilter.addAll('xml', 'orbit')
@@ -82,7 +67,6 @@ subprojects {
         failWhenNoMutations = false
         jvmArgs = ["-XX:+AllowRedefinitionToAddDeleteMethods"]
     }
-    {{/mutation}}
 
     jacocoTestReport {
         dependsOn test, 'pitest'
@@ -120,6 +104,7 @@ tasks.withType(JavaCompile).configureEach {
     ]
 }
 
+
 pitestReportAggregate {
     doLast {
         def reportDir = layout.buildDirectory.dir("reports/pitest").get().asFile
@@ -141,5 +126,5 @@ pitestReportAggregate {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '{{GRADLE_WRAPPER_VERSION}}'
+    gradleVersion = '8.11'
 }

--- a/src/test/resources/gradle-8.11-sample/main-before.txt
+++ b/src/test/resources/gradle-8.11-sample/main-before.txt
@@ -49,7 +49,7 @@ subprojects {
     test.finalizedBy(project.tasks.jacocoTestReport)
 
     pitest {
-        targetClasses = ['co.com.luisgomez29.*']
+        targetClasses = ['your.package.*']
         excludedClasses = []
         excludedTestClasses = []
         pitestVersion = '1.16.1'

--- a/src/test/resources/gradle-8.11-sample/main-before.txt
+++ b/src/test/resources/gradle-8.11-sample/main-before.txt
@@ -1,6 +1,4 @@
-{{#mutation}}
 apply plugin: 'info.solidsoft.pitest.aggregator'
-{{/mutation}}
 
 allprojects {
     repositories {
@@ -11,48 +9,35 @@ allprojects {
 }
 
 subprojects {
+    apply plugin: 'info.solidsoft.pitest'
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'io.spring.dependency-management'
-    {{#mutation}}
-    apply plugin: 'info.solidsoft.pitest'
-    {{/mutation}}
 
     compileJava.dependsOn validateStructure
-
-    java {
-        sourceCompatibility = JavaVersion.{{javaVersion}}
-    }
-
-    {{#mutation}}
-    //build.dependsOn 'pitest'
-    {{/mutation}}
+    sourceCompatibility = JavaVersion.VERSION_17
 
     test {
         useJUnitPlatform()
     }
 
     dependencies {
-        {{#reactive}}
+		implementation platform('software.amazon.awssdk:bom:2.29.15')
         implementation 'io.projectreactor:reactor-core'
         implementation 'io.projectreactor.addons:reactor-extra'
 
-        testImplementation 'io.projectreactor.tools:blockhound-junit-platform:{{BLOCK_HOUND_VERSION}}'
+        testImplementation 'io.projectreactor.tools:blockhound-junit-platform:1.0.10.RELEASE'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
         testImplementation 'io.projectreactor:reactor-test'
-        {{/reactive}}
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
-        {{#lombok}}
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
         testCompileOnly  "org.projectlombok:lombok:${lombokVersion}"
         testAnnotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
-        {{/lombok}}
         implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
     }
 
-    {{#reactive}}
     tasks.withType(Test).configureEach {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
             jvmArgs += [
@@ -60,21 +45,18 @@ subprojects {
             ]
         }
     }
-    {{/reactive}}
 
     test.finalizedBy(project.tasks.jacocoTestReport)
 
-    {{#mutation}}
     pitest {
-        targetClasses = ['{{package}}.*']
+        targetClasses = ['co.com.luisgomez29.*']
         excludedClasses = []
         excludedTestClasses = []
-        pitestVersion = '1.17.1'
+        pitestVersion = '1.16.1'
         verbose = true
         outputFormats = ['XML', 'HTML']
         threads = 8
         exportLineCoverage = true
-        useClasspathFile = true
         timestampedReports = false
         //mutators = ['STRONGER', 'DEFAULTS']
         fileExtensionsToFilter.addAll('xml', 'orbit')
@@ -82,7 +64,6 @@ subprojects {
         failWhenNoMutations = false
         jvmArgs = ["-XX:+AllowRedefinitionToAddDeleteMethods"]
     }
-    {{/mutation}}
 
     jacocoTestReport {
         dependsOn test, 'pitest'
@@ -120,6 +101,7 @@ tasks.withType(JavaCompile).configureEach {
     ]
 }
 
+
 pitestReportAggregate {
     doLast {
         def reportDir = layout.buildDirectory.dir("reports/pitest").get().asFile
@@ -141,5 +123,5 @@ pitestReportAggregate {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '{{GRADLE_WRAPPER_VERSION}}'
+    gradleVersion = '8.10.2'
 }


### PR DESCRIPTION
Updated to Gradle version 8.11 according to the changes [Deprecated java plugin conventions](https://docs.gradle.org/current/userguide/upgrading_version_8.html#java_convention_deprecation)

## Category
- [x] Feature
- [ ] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [x] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
