### PR TITLE
fix(gradle): fix UpgradeAction for gradle 8.11

### DIFF
--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
@@ -17,6 +17,10 @@ public class UpgradeY2024M11D16Gradle implements UpgradeAction {
     return builder.updateFile(
         MAIN_GRADLE,
         content -> {
+          if (!builder.findExpressions(MAIN_GRADLE, "java ?\\{").isEmpty()) {
+            return content;
+          }
+
           String sourceCompatibilityLoaded =
               builder
                   .findExpressions(

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
@@ -17,7 +17,7 @@ public class UpgradeY2024M11D16Gradle implements UpgradeAction {
     return builder.updateFile(
         MAIN_GRADLE,
         content -> {
-          if (!builder.findExpressions(MAIN_GRADLE, "java ?\\{").isEmpty()) {
+          if (!builder.findExpressions(MAIN_GRADLE, "java\\s*\\{").isEmpty()) {
             return content;
           }
 

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16GradleTest.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16GradleTest.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.factory.upgrades.actions;
 
 import static co.com.bancolombia.Constants.MainFiles.MAIN_GRADLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
@@ -53,6 +54,22 @@ class UpgradeY2024M11D16GradleTest {
     boolean applied = updater.up(builder);
     // Assert
     assertTrue(applied);
+    verify(builder)
+        .addFile(
+            MAIN_GRADLE,
+            FileUtils.getResourceAsString(resolver, "gradle-8.11-sample/main-after.txt"));
+  }
+
+  @Test
+  void shouldNotApplyUpdateIfJavaBlockExists() throws IOException {
+    DefaultResolver resolver = new DefaultResolver();
+    // Arrange
+    builder.addFile(
+        MAIN_GRADLE, FileUtils.getResourceAsString(resolver, "gradle-8.11-sample/main-after.txt"));
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertFalse(applied);
     verify(builder)
         .addFile(
             MAIN_GRADLE,


### PR DESCRIPTION
Add validation in Gradle 8.11 upgrade action to avoid duplicating `java {}` block in main.gradle file #585

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
