### PR TITLE
fix: add config test when router option is true

### DIFF
--- a/src/main/resources/entry-point/rest-webflux/router-functions/config.unit.test.java.mustache
+++ b/src/main/resources/entry-point/rest-webflux/router-functions/config.unit.test.java.mustache
@@ -1,0 +1,36 @@
+package {{package}}.api.config;
+
+import {{package}}.api.Handler;
+import {{package}}.api.RouterRest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@ContextConfiguration(classes = {RouterRest.class, Handler.class})
+@WebFluxTest
+@Import({CorsConfig.class, SecurityHeadersConfig.class})
+class ConfigTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void corsConfigurationShouldAllowOrigins() {
+        webTestClient.get()
+                .uri("/api/usecase/path")
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals("Content-Security-Policy",
+                        "default-src 'self'; frame-ancestors 'self'; form-action 'self'")
+                .expectHeader().valueEquals("Strict-Transport-Security", "max-age=31536000;")
+                .expectHeader().valueEquals("X-Content-Type-Options", "nosniff")
+                .expectHeader().valueEquals("Server", "")
+                .expectHeader().valueEquals("Cache-Control", "no-store")
+                .expectHeader().valueEquals("Pragma", "no-cache")
+                .expectHeader().valueEquals("Referrer-Policy", "strict-origin-when-cross-origin");
+    }
+
+}

--- a/src/main/resources/entry-point/rest-webflux/router-functions/definition.json
+++ b/src/main/resources/entry-point/rest-webflux/router-functions/definition.json
@@ -8,6 +8,7 @@
     "entry-point/rest-webflux/cors-config.java.mustache": "infrastructure/entry-points/reactive-web/src/main/java/{{packagePath}}/api/config/CorsConfig.java",
     "entry-point/rest-webflux/security-headers-filter.java.mustache": "infrastructure/entry-points/reactive-web/src/main/java/{{packagePath}}/api/config/SecurityHeadersConfig.java",
     "entry-point/rest-webflux/router-functions/router.unit.test.java.mustache": "infrastructure/entry-points/reactive-web/src/test/java/{{packagePath}}/api/RouterRestTest.java",
+    "entry-point/rest-webflux/router-functions/config.unit.test.java.mustache": "infrastructure/entry-points/reactive-web/src/test/java/{{packagePath}}/api/config/ConfigTest.java",
     "entry-point/rest-webflux/build.gradle.mustache": "infrastructure/entry-points/reactive-web/build.gradle"
   }
 }


### PR DESCRIPTION
## Description
Create template for webflux router tests

## Category
- [x] Tests

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [x] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [x] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [x] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
