### PR TITLE
fix: Add api performance-test when reactive-web or api-rest modules exists

### DIFF
--- a/src/main/java/co/com/bancolombia/factory/tests/performance/PerformanceTestJmeter.java
+++ b/src/main/java/co/com/bancolombia/factory/tests/performance/PerformanceTestJmeter.java
@@ -15,12 +15,6 @@ public class PerformanceTestJmeter implements ModuleFactory {
       templatePath += "/Jmeter/Api";
     }
 
-    System.out.println(
-        "**** "
-            + builder.getBooleanParam("task-param-exist-api-rest")
-            + " -> "
-            + templatePath
-            + " ****");
     builder.setupFromTemplate(templatePath);
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/tests/performance/PerformanceTestJmeter.java
+++ b/src/main/java/co/com/bancolombia/factory/tests/performance/PerformanceTestJmeter.java
@@ -9,6 +9,18 @@ public class PerformanceTestJmeter implements ModuleFactory {
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
-    builder.setupFromTemplate("test/performance-test/jmeter");
+    String templatePath = "test/performance-test/jmeter";
+
+    if (Boolean.TRUE.equals(builder.getBooleanParam("task-param-exist-api-rest"))) {
+      templatePath += "/Jmeter/Api";
+    }
+
+    System.out.println(
+        "**** "
+            + builder.getBooleanParam("task-param-exist-api-rest")
+            + " -> "
+            + templatePath
+            + " ****");
+    builder.setupFromTemplate(templatePath);
   }
 }

--- a/src/main/java/co/com/bancolombia/task/GeneratePerformanceTestTask.java
+++ b/src/main/java/co/com/bancolombia/task/GeneratePerformanceTestTask.java
@@ -12,7 +12,7 @@ public class GeneratePerformanceTestTask extends AbstractResolvableTypeTask {
   @Override
   protected void prepareParams() {
     var modules = new ArrayList<>(getProject().getChildProjects().keySet());
-    System.out.printf("Modules: %s%n", modules);
+
     builder.addParam(
         "task-param-exist-api-rest",
         modules.stream()

--- a/src/main/java/co/com/bancolombia/task/GeneratePerformanceTestTask.java
+++ b/src/main/java/co/com/bancolombia/task/GeneratePerformanceTestTask.java
@@ -1,6 +1,7 @@
 package co.com.bancolombia.task;
 
 import co.com.bancolombia.task.annotations.CATask;
+import java.util.ArrayList;
 
 @CATask(
     name = "generatePerformanceTest",
@@ -10,7 +11,12 @@ public class GeneratePerformanceTestTask extends AbstractResolvableTypeTask {
 
   @Override
   protected void prepareParams() {
-    // No additional params required
+    var modules = new ArrayList<>(getProject().getChildProjects().keySet());
+    System.out.printf("Modules: %s%n", modules);
+    builder.addParam(
+        "task-param-exist-api-rest",
+        modules.stream()
+            .anyMatch(value -> value.equals("reactive-web") || value.equals("api-rest")));
   }
 
   @Override

--- a/src/main/resources/test/performance-test/jmeter/Jmeter/Api/definition.json
+++ b/src/main/resources/test/performance-test/jmeter/Jmeter/Api/definition.json
@@ -1,0 +1,12 @@
+{
+  "folders": [],
+  "files": {
+    "test/performance-test/jmeter/Jmeter/Api/README.md.mustache": "deployment/performance-test/Jmeter/Api/README.md",
+
+    "test/performance-test/jmeter/Jmeter/Api/SC_Template_UDP_Service.jmx.mustache": "deployment/performance-test/Jmeter/Api/SC_Template_UDP_Service.jmx",
+    "test/performance-test/jmeter/Jmeter/Api/SC_Template_HTTP_Service.jmx.mustache": "deployment/performance-test/Jmeter/Api/SC_Template_HTTP_Service.jmx",
+
+    "test/performance-test/jmeter/Jmeter/Api/DataSet/DT_Example.csv.mustache": "deployment/performance-test/Jmeter/Api/DataSet/DT_Example.csv",
+    "test/performance-test/jmeter/Jmeter/Api/DataSet/DT_Example.txt.mustache": "deployment/performance-test/Jmeter/Api/DataSet/DT_Example.txt"
+  }
+}

--- a/src/test/java/co/com/bancolombia/task/GeneratePerformanceTestTaskTest.java
+++ b/src/test/java/co/com/bancolombia/task/GeneratePerformanceTestTaskTest.java
@@ -13,20 +13,18 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 class GeneratePerformanceTestTaskTest {
   private static final String TEST_DIR = getTestDir(GeneratePerformanceTestTaskTest.class);
+  private static Project project;
 
   private static GeneratePerformanceTestTask task;
 
-  @BeforeAll
-  public static void setup() throws IOException, CleanException {
+  @BeforeEach
+  public void setup() throws IOException, CleanException {
     deleteStructure(Path.of(TEST_DIR));
-    Project project =
-        setupProject(GeneratePerformanceTestTaskTest.class, GenerateStructureTask.class);
+    project = setupProject(GeneratePerformanceTestTaskTest.class, GenerateStructureTask.class);
 
     GenerateStructureTask taskStructure = getTask(project, GenerateStructureTask.class);
     taskStructure.setType(GenerateStructureTask.ProjectType.REACTIVE);
@@ -41,8 +39,8 @@ class GeneratePerformanceTestTaskTest {
     task = createTask(project, GeneratePerformanceTestTask.class);
   }
 
-  @AfterAll
-  public static void tearDown() {
+  @AfterEach
+  public void tearDown() {
     deleteStructure(Path.of(TEST_DIR));
   }
 
@@ -51,5 +49,26 @@ class GeneratePerformanceTestTaskTest {
     task.setType("JMETER");
     task.execute();
     assertFilesExistsInDir(TEST_DIR + "/performance-test/", "Jmeter", "README.md");
+  }
+
+  @Test
+  void generateApiPerformanceTest() throws IOException, CleanException {
+    // Arrange
+    ProjectBuilder.builder()
+        .withName("reactive-web")
+        .withProjectDir(new File(TEST_DIR + "/infrastructure/entry-points/reactive-web"))
+        .withParent(project)
+        .build();
+
+    task.setType("JMETER");
+
+    // Act
+    task.execute();
+    // Assert
+    assertFilesExistsInDir(
+        TEST_DIR + "/deployment/performance-test/Jmeter/Api/",
+        "README.md",
+        "SC_Template_UDP_Service.jmx",
+        "SC_Template_HTTP_Service.jmx");
   }
 }


### PR DESCRIPTION
## Description
Generate only api performance-test when reactive-web or api-rest modules are created in the deployment folder path project

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [x] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [x] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [x] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
