### PR TITLE
feat: add update action for SonarQube properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.3.1'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
-    id 'org.owasp.dependencycheck' version '12.1.1'
+    id 'org.owasp.dependencycheck' version '12.1.3'
 }
 
 ext {
@@ -177,37 +177,37 @@ if (project.hasProperty('signing.keyId')) { // publish as library in maven centr
 
 dependencies {
     api 'com.github.spullara.mustache.java:compiler:0.9.14'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.0'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.0'
-    api 'commons-io:commons-io:2.19.0'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.2'
+    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.2'
+    api 'commons-io:commons-io:2.20.0'
     api gradleApi()
 
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2'
     implementation 'org.reflections:reflections:0.10.2'
     // swagger generators
-    implementation('io.swagger.codegen.v3:swagger-codegen-generators:1.0.56') {
+    implementation('io.swagger.codegen.v3:swagger-codegen-generators:1.0.57') {
         exclude group: 'net.sf.jopt-simple', module: 'jopt-simple'
     }
     constraints { // for previous swagger dependency
-        implementation('commons-codec:commons-codec:1.18.0') {
+        implementation('commons-codec:commons-codec:1.19.0') {
             because "This version closes a security vulnerability"
         }
     }
     implementation 'com.googlecode.lambdaj:lambdaj:2.3.3'
-    implementation 'com.google.googlejavaformat:google-java-format:1.27.0'
+    implementation 'com.google.googlejavaformat:google-java-format:1.28.0'
 
     testImplementation gradleTestKit()
     testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.12.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.12.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.13.4'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.13.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.4'
 
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.1.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:5.1.0'
 }
 
 jacocoTestReport {
@@ -291,7 +291,7 @@ tasks.register('installGitHooks') {
 }
 
 tasks.named('wrapper') {
-    gradleVersion = '8.14.1'
+    gradleVersion = '8.14.3'
 }
 
 tasks.register('ci-updater', JavaExec) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -12,20 +12,20 @@ public final class Constants {
   public static final String APP_SERVICE = "app-service";
   public static final String PATH_GRAPHQL = "/graphql";
   // dependencies
-  public static final String SECRETS_VERSION = "4.4.33";
-  public static final String SPRING_BOOT_VERSION = "3.5.3";
+  public static final String SECRETS_VERSION = "4.4.34";
+  public static final String SPRING_BOOT_VERSION = "3.5.4";
   public static final String LOMBOK_VERSION = "1.18.38";
-  public static final String REACTIVE_COMMONS_VERSION = "5.4.1";
+  public static final String REACTIVE_COMMONS_VERSION = "5.5.0";
   public static final String REACTIVE_COMMONS_MAPPER_VERSION = "0.1.0";
-  public static final String BLOCK_HOUND_VERSION = "1.0.11.RELEASE";
-  public static final String AWS_BOM_VERSION = "2.32.3";
-  public static final String COMMONS_JMS_VERSION = "2.4.2";
+  public static final String BLOCK_HOUND_VERSION = "1.0.13.RELEASE";
+  public static final String AWS_BOM_VERSION = "2.32.13";
+  public static final String COMMONS_JMS_VERSION = "2.4.5";
   public static final String GRAPHQL_KICKSTART_VERSION = "15.1.0";
-  public static final String ARCH_UNIT_VERSION = "1.4.0";
-  public static final String OKHTTP_VERSION = "4.12.0";
+  public static final String ARCH_UNIT_VERSION = "1.4.1";
+  public static final String OKHTTP_VERSION = "5.1.0";
   public static final String RESILIENCE_4J_VERSION = "2.3.0";
   public static final String BIN_STASH_VERSION = "1.3.1";
-  public static final String SPRING_DOC_OPENAPI_VERSION = "2.8.8";
+  public static final String SPRING_DOC_OPENAPI_VERSION = "2.8.9";
   public static final String CLOUD_EVENTS_VERSION = "4.0.1";
   // gradle plugins
   public static final String JACOCO_VERSION = "0.8.13";

--- a/src/main/java/co/com/bancolombia/factory/pipelines/PipelineAzure.java
+++ b/src/main/java/co/com/bancolombia/factory/pipelines/PipelineAzure.java
@@ -9,8 +9,6 @@ public class PipelineAzure implements ModuleFactory {
 
   @Override
   public void buildModule(ModuleBuilder builder) throws IOException, CleanException {
-    builder.addParam("sonar.java.binaries", "**/build/classes/java/main");
-    builder.addParam("sonar.junit.reportsPaths", "**/build/test-results/test");
     builder.setupFromTemplate("pipeline/azure");
   }
 }

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2022M05D05.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2022M05D05.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 public class UpgradeY2022M05D05 implements UpgradeAction {
   @Override
-  @SuppressWarnings("unchecked")
   public boolean up(ModuleBuilder builder) {
     String name = builder.getProject().getRootProject().getName();
     try {

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2024M11D16Gradle.java
@@ -43,7 +43,7 @@ public class UpgradeY2024M11D16Gradle implements UpgradeAction {
 
   @Override
   public String name() {
-    return "3.18.2->3.18.3";
+    return "3.18.2->3.19.0";
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M03D08Gradle.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M03D08Gradle.java
@@ -26,7 +26,7 @@ public class UpgradeY2025M03D08Gradle implements UpgradeAction {
 
   @Override
   public String name() {
-    return "3.18.3->3.20.16";
+    return "3.20.6->3.20.15";
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M05D10Cache.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M05D10Cache.java
@@ -43,44 +43,42 @@ public class UpgradeY2025M05D10Cache implements UpgradeAction {
         | builder.updateFile(
             GRADLE_PROPERTIES,
             content -> {
-              String modifiedContent = content;
-
-              modifiedContent =
+              content =
                   updateGradleProperties(
                       builder,
-                      modifiedContent,
+                      content,
                       CONFIGURATION_CACHE_INTEGRITY_REGEX,
                       "org.gradle.configuration-cache.integrity-check=false",
                       "org.gradle.configuration-cache.integrity-check=",
                       CONFIGURATION_CACHE_INTEGRITY);
 
-              modifiedContent =
+              content =
                   updateGradleProperties(
                       builder,
-                      modifiedContent,
+                      content,
                       CONFIGURATION_CACHE_PARALLEL_REGEX,
                       "org.gradle.configuration-cache.parallel=false",
                       "org.gradle.configuration-cache.parallel=",
                       CONFIGURATION_CACHE_PARALLEL);
 
-              modifiedContent =
+              content =
                   updateGradleProperties(
                       builder,
-                      modifiedContent,
+                      content,
                       CONFIGURATION_CACHE_REGEX,
                       "org.gradle.configuration-cache=false",
                       "org.gradle.configuration-cache=",
                       CONFIGURATION_CACHE);
-              modifiedContent =
+              content =
                   updateGradleProperties(
                       builder,
-                      modifiedContent,
+                      content,
                       CACHING_REGEX,
                       "org.gradle.caching=false",
                       "org.gradle.caching=",
                       CACHING);
 
-              return modifiedContent;
+              return content;
             })
         | UpdateUtils.appendIfNotContains(builder, "./.gitignore", "build-cache", "\nbuild-cache");
   }
@@ -100,7 +98,7 @@ public class UpgradeY2025M05D10Cache implements UpgradeAction {
 
   @Override
   public String name() {
-    return "3.22.4->3.22.5";
+    return "3.22.4->3.23.0";
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01Sonar.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01Sonar.java
@@ -1,0 +1,44 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.BUILD_GRADLE;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import lombok.SneakyThrows;
+
+public class UpgradeY2025M08D01Sonar implements UpgradeAction {
+  private static final String SONAR_TESTS_REGEX = "\"sonar\\.test\"";
+  private static final String SONAR_JAVA_BINARIES_REGEX =
+      "\"sonar\\.java\\.binaries\",\\s*\"([^\"]*)\"";
+  private static final String SONAR_JUNIT_REPORTS_PATH_REGEX =
+      "\"sonar\\.junit\\.reportsPath\",\\s*\"([^\"]*)\"";
+
+  @Override
+  @SneakyThrows
+  public boolean up(ModuleBuilder builder) {
+    return builder.updateFile(
+            BUILD_GRADLE, content -> content.replaceAll(SONAR_TESTS_REGEX, "\"sonar.tests\""))
+        | builder.updateFile(
+            BUILD_GRADLE,
+            content ->
+                content.replaceAll(
+                    SONAR_JAVA_BINARIES_REGEX,
+                    "\"sonar.java.binaries\", \"**/build/classes/java/main\""))
+        | builder.updateFile(
+            BUILD_GRADLE,
+            content ->
+                content.replaceAll(
+                    SONAR_JUNIT_REPORTS_PATH_REGEX,
+                    "\"sonar.junit.reportsPath\", \"**/build/test-results/test\""));
+  }
+
+  @Override
+  public String name() {
+    return "3.23.2->3.23.3";
+  }
+
+  @Override
+  public String description() {
+    return "Add block hound validations";
+  }
+}

--- a/src/main/resources/driven-adapter/mq-sender/sample-mq-message-sender.java.mustache
+++ b/src/main/resources/driven-adapter/mq-sender/sample-mq-message-sender.java.mustache
@@ -3,7 +3,7 @@ package {{package}}.mq.sender;
 import co.com.bancolombia.commons.jms.api.MQMessageSender;
 import co.com.bancolombia.commons.jms.mq.EnableMQGateway;
 {{#lombok}}
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 {{/lombok}}
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -12,7 +12,7 @@ import jakarta.jms.Message;
 
 @Component
 {{#lombok}}
-@AllArgsConstructor
+@RequiredArgsConstructor
 {{/lombok}}
 @EnableMQGateway(scanBasePackages = "{{package}}")
 public class SampleMQMessageSender /* implements SomeGateway */ {

--- a/src/main/resources/driven-adapter/mq-sender/sample-mq-req-reply.java.mustache
+++ b/src/main/resources/driven-adapter/mq-sender/sample-mq-req-reply.java.mustache
@@ -2,7 +2,7 @@ package {{package}}.mq.reqreply;
 
 import co.com.bancolombia.commons.jms.mq.EnableMQGateway;
 {{#lombok}}
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 {{/lombok}}
 import org.springframework.stereotype.Component;
@@ -13,7 +13,7 @@ import jakarta.jms.TextMessage;
 
 @Component
 {{#lombok}}
-@AllArgsConstructor
+@RequiredArgsConstructor
 {{/lombok}}
 @EnableMQGateway(scanBasePackages = "{{package}}")
 public class SampleMQReqReply /* implements SomeGateway */ {

--- a/src/main/resources/pipeline/azure/azure.yaml.mustache
+++ b/src/main/resources/pipeline/azure/azure.yaml.mustache
@@ -21,108 +21,115 @@ trigger:
       - feature/*
 
 stages:
-- stage: CI
-  jobs:
-  - job: build
-    displayName: 'Build'
-    pool:
-      name: Build
-      demands:
-        - java
-    steps:
-    - task: SonarQubePrepare@5
-      displayName: 'Prepare analysis on SonarQube'
-      inputs:
-        SonarQube: SonarQube
-        scannerMode: Other
-        extraProperties: |
-          {{#monoRepo}}
-          sonar.projectKey=$(Build.Repository.Name)_$(projectName)
-          sonar.projectName=$(Build.Repository.Name)_$(projectName)
-          {{/monoRepo}}
-          {{^monoRepo}}
-          sonar.projectKey=$(Build.Repository.Name)
-          sonar.projectName=$(Build.Repository.Name)
-          {{/monoRepo}}
-          sonar.projectVersion=$(Build.BuildNumber)
+  - stage: CI
+    jobs:
+      - job: build
+        displayName: 'Build'
+        pool:
+          name: Build
+        steps:
+          - checkout: self
+            fetchDepth: 0
 
-    - task: Gradle@4
-      displayName: 'Build and Test'
-      condition: succeeded()
-      inputs:
-        {{#monoRepo}}
-        workingDirectory: $(projectName)
-        gradleWrapperFile: $(projectName)/gradlew
-        {{/monoRepo}}
-        {{^monoRepo}}
-        workingDirectory: .
-        gradleWrapperFile: gradlew
-        {{/monoRepo}}
-        tasks: 'clean build jacocoMergedReport'
-        publishJUnitResults: true
-        testResultsFiles: '**/TEST-*.xml'
-        sonarQubeRunAnalysis: true
-        sqGradlePluginVersionChoice: 'build'
-        javaHomeOption: 'JDKVersion'
+          - task: JavaToolInstaller@1
+            inputs:
+              versionSpec: '21'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
 
-    - task: PublishCodeCoverageResults@2
-      displayName: 'Publish code coverage'
-      inputs:
-        {{#monoRepo}}
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/html'
-        {{/monoRepo}}
-        {{^monoRepo}}
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/html'
-        {{/monoRepo}}
+          - task: SonarQubePrepare@7
+            displayName: 'Prepare analysis on SonarQube'
+            inputs:
+              SonarQube: SonarQube
+              scannerMode: Other
+              extraProperties: |
+                {{#monoRepo}}
+                sonar.projectKey=$(Build.Repository.Name)_$(projectName)
+                sonar.projectName=$(Build.Repository.Name)_$(projectName)
+                {{/monoRepo}}
+                {{^monoRepo}}
+                sonar.projectKey=$(Build.Repository.Name)
+                sonar.projectName=$(Build.Repository.Name)
+                {{/monoRepo}}
+                sonar.projectVersion=$(Build.BuildNumber)
 
-    - task: publish-report-html@0
-      displayName: 'Publish Mutation Report'
-      inputs:
-        reportName: 'Mutation Report'
-        {{#monoRepo}}
-        htmlPath: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/pitest/index.html'
-        {{/monoRepo}}
-        {{^monoRepo}}
-        htmlPath: '$(System.DefaultWorkingDirectory)/build/reports/pitest/index.html'
-        {{/monoRepo}}
+          - task: Gradle@4
+            displayName: 'Build and Test'
+            condition: succeeded()
+            inputs:
+              {{#monoRepo}}
+              workingDirectory: $(projectName)
+              gradleWrapperFile: $(projectName)/gradlew
+              {{/monoRepo}}
+              {{^monoRepo}}
+              workingDirectory: .
+              gradleWrapperFile: gradlew
+              {{/monoRepo}}
+              tasks: 'clean build jacocoMergedReport'
+              publishJUnitResults: true
+              testResultsFiles: '**/TEST-*.xml'
+              sonarQubeRunAnalysis: true
+              sqGradlePluginVersionChoice: 'build'
+              javaHomeOption: 'JDKVersion'
 
-    - task: Sonar-buildbreaker@8
-      displayName: 'Quality Gate'
-      inputs:
-        SonarQube: SonarQube
+          - task: PublishCodeCoverageResults@2
+            displayName: 'Publish code coverage'
+            inputs:
+              {{#monoRepo}}
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/html'
+              {{/monoRepo}}
+              {{^monoRepo}}
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/html'
+              {{/monoRepo}}
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact'
-      condition: in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/trunk', 'refs/heads/master')
-      inputs:
-        {{#monoRepo}}
-        PathtoPublish: '$(System.DefaultWorkingDirectory)/$(projectName)/applications/app-service/build/libs/'
-        {{/monoRepo}}
-        {{^monoRepo}}
-        PathtoPublish: '$(System.DefaultWorkingDirectory)/applications/app-service/build/libs/'
-        {{/monoRepo}}
-        ArtifactName: '$(Artifact.Name)'
+          - task: publish-report-html@0
+            displayName: 'Publish Mutation Report'
+            inputs:
+              reportName: 'Mutation Report'
+              {{#monoRepo}}
+              htmlPath: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/pitest/index.html'
+              {{/monoRepo}}
+              {{^monoRepo}}
+              htmlPath: '$(System.DefaultWorkingDirectory)/build/reports/pitest/index.html'
+              {{/monoRepo}}
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: test'
-      inputs:
-        {{#monoRepo}}
-        PathtoPublish: $(projectName)/deployment/acceptanceTest
-        {{/monoRepo}}
-        {{^monoRepo}}
-        PathtoPublish: deployment/acceptanceTest
-        {{/monoRepo}}
-        ArtifactName: test
+          - task: Sonar-buildbreaker@8
+            displayName: 'Quality Gate'
+            inputs:
+              SonarQube: SonarQube
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: Performance Test'
-      inputs:
-        {{#monoRepo}}
-        PathtoPublish: $(projectName)/deployment/performance-test/Jmeter/{{projectName}}
-        {{/monoRepo}}
-        {{^monoRepo}}
-        PathtoPublish: deployment/performance-test/Jmeter/{{projectName}}
-        {{/monoRepo}}
-        ArtifactName: PerformacerTest
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Artifact'
+            condition: in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/trunk', 'refs/heads/master')
+            inputs:
+              {{#monoRepo}}
+              PathtoPublish: '$(System.DefaultWorkingDirectory)/$(projectName)/applications/app-service/build/libs/'
+              {{/monoRepo}}
+              {{^monoRepo}}
+              PathtoPublish: '$(System.DefaultWorkingDirectory)/applications/app-service/build/libs/'
+              {{/monoRepo}}
+              ArtifactName: '$(Artifact.Name)'
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Artifact: test'
+            inputs:
+              {{#monoRepo}}
+              PathtoPublish: $(projectName)/deployment/acceptanceTest
+              {{/monoRepo}}
+              {{^monoRepo}}
+              PathtoPublish: deployment/acceptanceTest
+              {{/monoRepo}}
+              ArtifactName: test
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Artifact: Performance Test'
+            inputs:
+              {{#monoRepo}}
+              PathtoPublish: $(projectName)/deployment/performance-test/Jmeter/{{projectName}}
+              {{/monoRepo}}
+              {{^monoRepo}}
+              PathtoPublish: deployment/performance-test/Jmeter/{{projectName}}
+              {{/monoRepo}}
+              ArtifactName: PerformacerTest

--- a/src/main/resources/pipeline/azure/azure.yaml.mustache
+++ b/src/main/resources/pipeline/azure/azure.yaml.mustache
@@ -5,6 +5,8 @@ variables:
     value: 'build-{{projectName}}'
   - name: 'Artifact.Name'
     value: '{{projectName}}'
+  - name: 'projectName'
+    value: '{{projectName}}'
 
 resources:
   - repo: self
@@ -42,25 +44,49 @@ stages:
           sonar.projectKey=$(Build.Repository.Name)
           sonar.projectName=$(Build.Repository.Name)
           {{/monoRepo}}
-
           sonar.projectVersion=$(Build.BuildNumber)
 
-    - task: Gradle@3
+    - task: Gradle@4
       displayName: 'Build and Test'
+      condition: succeeded()
       inputs:
+        {{#monoRepo}}
+        workingDirectory: $(projectName)
+        gradleWrapperFile: $(projectName)/gradlew
+        {{/monoRepo}}
+        {{^monoRepo}}
         workingDirectory: .
         gradleWrapperFile: gradlew
+        {{/monoRepo}}
         tasks: 'clean build jacocoMergedReport'
         publishJUnitResults: true
         testResultsFiles: '**/TEST-*.xml'
         sonarQubeRunAnalysis: true
         sqGradlePluginVersionChoice: 'build'
+        javaHomeOption: 'JDKVersion'
 
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       displayName: 'Publish code coverage'
       inputs:
+        {{#monoRepo}}
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
+        reportDirectory: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/jacocoMergedReport/html'
+        {{/monoRepo}}
+        {{^monoRepo}}
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/jacocoMergedReport.xml'
         reportDirectory: '$(System.DefaultWorkingDirectory)/build/reports/jacocoMergedReport/html'
+        {{/monoRepo}}
+
+    - task: publish-report-html@0
+      displayName: 'Publish Mutation Report'
+      inputs:
+        reportName: 'Mutation Report'
+        {{#monoRepo}}
+        htmlPath: '$(System.DefaultWorkingDirectory)/$(projectName)/build/reports/pitest/index.html'
+        {{/monoRepo}}
+        {{^monoRepo}}
+        htmlPath: '$(System.DefaultWorkingDirectory)/build/reports/pitest/index.html'
+        {{/monoRepo}}
 
     - task: Sonar-buildbreaker@8
       displayName: 'Quality Gate'
@@ -71,5 +97,32 @@ stages:
       displayName: 'Publish Artifact'
       condition: in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/trunk', 'refs/heads/master')
       inputs:
+        {{#monoRepo}}
+        PathtoPublish: '$(System.DefaultWorkingDirectory)/$(projectName)/applications/app-service/build/libs/'
+        {{/monoRepo}}
+        {{^monoRepo}}
         PathtoPublish: '$(System.DefaultWorkingDirectory)/applications/app-service/build/libs/'
+        {{/monoRepo}}
         ArtifactName: '$(Artifact.Name)'
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: test'
+      inputs:
+        {{#monoRepo}}
+        PathtoPublish: $(projectName)/deployment/acceptanceTest
+        {{/monoRepo}}
+        {{^monoRepo}}
+        PathtoPublish: deployment/acceptanceTest
+        {{/monoRepo}}
+        ArtifactName: test
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: Performance Test'
+      inputs:
+        {{#monoRepo}}
+        PathtoPublish: $(projectName)/deployment/performance-test/Jmeter/{{projectName}}
+        {{/monoRepo}}
+        {{^monoRepo}}
+        PathtoPublish: deployment/performance-test/Jmeter/{{projectName}}
+        {{/monoRepo}}
+        ArtifactName: PerformacerTest

--- a/src/main/resources/structure/root/build.gradle.mustache
+++ b/src/main/resources/structure/root/build.gradle.mustache
@@ -61,9 +61,9 @@ sonar {
         {{^example}}
         property "sonar.exclusions","**/MainApplication.java"
         {{/example}}
-        property "sonar.test", "src/test"
-        property "sonar.java.binaries", "{{sonar.java.binaries}}"
-        property "sonar.junit.reportsPath", "{{sonar.junit.reportsPaths}}"
+        property "sonar.tests", "src/test"
+        property "sonar.java.binaries", "**/build/classes/java/main"
+        property "sonar.junit.reportsPath", "**/build/test-results/test"
         property "sonar.java.coveragePlugin", "jacoco"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacocoMergedReport/jacocoMergedReport.xml"
         property "sonar.pitest.reportPaths", "build/reports/pitest/mutations.xml"

--- a/src/main/resources/structure/root/main.gradle.mustache
+++ b/src/main/resources/structure/root/main.gradle.mustache
@@ -70,7 +70,7 @@ subprojects {
         targetClasses = ['{{package}}.*']
         excludedClasses = []
         excludedTestClasses = []
-        pitestVersion = '1.19.4'
+        pitestVersion = '1.20.1'
         verbose = false
         outputFormats = ['XML', 'HTML']
         threads = 8

--- a/src/main/resources/test/acceptance-test/build.gradle.mustache
+++ b/src/main/resources/test/acceptance-test/build.gradle.mustache
@@ -24,10 +24,18 @@ dependencies {
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${fasterxmlJacksonCoreVersion}"
 }
 
+sourceSets {
+    test {
+        resources {
+            srcDir file('src/test/java')
+            exclude '**/*.java'
+        }
+    }
+}
+
 test {
     useJUnitPlatform()
     systemProperty "karate.options", System.properties.getProperty("karate.options")
     systemProperty "karate.env", System.properties.getProperty("karate.env")
     outputs.upToDateWhen { false }
 }
-

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01SonarTest.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01SonarTest.java
@@ -18,8 +18,11 @@ import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class UpgradeY2025M08D01SonarTest {
   @Mock private Project project;
   @Mock private Logger logger;

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01SonarTest.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M08D01SonarTest.java
@@ -1,0 +1,60 @@
+package co.com.bancolombia.factory.upgrades.actions;
+
+import static co.com.bancolombia.Constants.MainFiles.BUILD_GRADLE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.com.bancolombia.factory.ModuleBuilder;
+import co.com.bancolombia.factory.upgrades.UpgradeAction;
+import co.com.bancolombia.utils.FileUtils;
+import com.github.mustachejava.resolver.DefaultResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class UpgradeY2025M08D01SonarTest {
+  @Mock private Project project;
+  @Mock private Logger logger;
+
+  private ModuleBuilder builder;
+  private UpgradeAction updater;
+
+  @BeforeEach
+  void setup() throws IOException {
+    when(project.getName()).thenReturn("UtilsTest");
+    when(project.getLogger()).thenReturn(logger);
+    when(project.getProjectDir()).thenReturn(Files.createTempDirectory("sample").toFile());
+
+    builder = spy(new ModuleBuilder(project));
+    updater = new UpgradeY2025M08D01Sonar();
+
+    assertNotNull(updater.name());
+    assertNotNull(updater.description());
+  }
+
+  @Test
+  void shouldApplyUpdate() throws IOException {
+    DefaultResolver resolver = new DefaultResolver();
+    // Arrange
+    builder.addFile(
+        BUILD_GRADLE,
+        FileUtils.getResourceAsString(resolver, "sonar-properties/sonarqube-task-before.txt"));
+
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertTrue(applied);
+    verify(builder, atLeast(1))
+        .addFile(
+            BUILD_GRADLE,
+            FileUtils.getResourceAsString(resolver, "sonar-properties/sonarqube-task-after.txt"));
+  }
+}

--- a/src/test/resources/sonar-properties/sonarqube-task-after.txt
+++ b/src/test/resources/sonar-properties/sonarqube-task-after.txt
@@ -1,0 +1,16 @@
+sonar {
+    def modules = subprojects.projectDir.collect { "${it.toString().replace(project.projectDir.toString() + "/", "")}" }
+    properties {
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.modules", "${modules.join(',')}"
+        property "sonar.sources", "src,deployment,settings.gradle,main.gradle,build.gradle,${modules.collect { "${it}/build.gradle" }.join(',')}"
+        property "sonar.tests", "src/test"
+        property "sonar.java.binaries", "**/build/classes/java/main"
+        property "sonar.junit.reportsPath", "**/build/test-results/test"
+        property "sonar.java.coveragePlugin", "jacoco"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacocoMergedReport/jacocoMergedReport.xml"
+        property "sonar.externalIssuesReportPaths", "build/issues.json"
+    }
+}
+
+apply from: './main.gradle'

--- a/src/test/resources/sonar-properties/sonarqube-task-before.txt
+++ b/src/test/resources/sonar-properties/sonarqube-task-before.txt
@@ -1,12 +1,12 @@
-sonarqube {
+sonar {
     def modules = subprojects.projectDir.collect { "${it.toString().replace(project.projectDir.toString() + "/", "")}" }
     properties {
         property "sonar.sourceEncoding", "UTF-8"
         property "sonar.modules", "${modules.join(',')}"
         property "sonar.sources", "src,deployment,settings.gradle,main.gradle,build.gradle,${modules.collect { "${it}/build.gradle" }.join(',')}"
         property "sonar.test", "src/test"
-        property "sonar.java.binaries", "{{sonar.java.binaries}}"
-        property "sonar.junit.reportsPath", "{{sonar.junit.reportsPaths}}"
+        property "sonar.java.binaries", ""
+        property "sonar.junit.reportsPath", ""
         property "sonar.java.coveragePlugin", "jacoco"
         property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacocoMergedReport/jacocoMergedReport.xml"
         property "sonar.externalIssuesReportPaths", "build/issues.json"

--- a/src/test/resources/sonar-properties/sonarqube-task-before.txt
+++ b/src/test/resources/sonar-properties/sonarqube-task-before.txt
@@ -1,0 +1,16 @@
+sonarqube {
+    def modules = subprojects.projectDir.collect { "${it.toString().replace(project.projectDir.toString() + "/", "")}" }
+    properties {
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.modules", "${modules.join(',')}"
+        property "sonar.sources", "src,deployment,settings.gradle,main.gradle,build.gradle,${modules.collect { "${it}/build.gradle" }.join(',')}"
+        property "sonar.test", "src/test"
+        property "sonar.java.binaries", "{{sonar.java.binaries}}"
+        property "sonar.junit.reportsPath", "{{sonar.junit.reportsPaths}}"
+        property "sonar.java.coveragePlugin", "jacoco"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacocoMergedReport/jacocoMergedReport.xml"
+        property "sonar.externalIssuesReportPaths", "build/issues.json"
+    }
+}
+
+apply from: './main.gradle'


### PR DESCRIPTION
A new update action has been created to modify the `build.gradle` file.

*   The deprecated property `sonar.test` is updated to `sonar.tests`.
*   The `sonar.java.binaries` property is correctly configured with the value `**/build/classes/java/main`.
*   The `sonar.junit.reportsPath` property is correctly configured with the value `**/build/test-results/test`.

The Azure pipeline template and plugin dependencies are also updated.

## Category
- [x] Feature
- [ ] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
- [x] Automated tests are written
- [x] The documentation is up-to-date
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog
- [ ] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#more-on-pull-requests)
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing)
