### PR TITLE
chore: Update Pitest configuration and dependency versions

### DIFF
--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -15,10 +15,10 @@ public final class Constants {
   public static final String SECRETS_VERSION = "4.5.2";
   public static final String SPRING_BOOT_VERSION = "4.1.0";
   public static final String LOMBOK_VERSION = "1.18.46";
-  public static final String REACTIVE_COMMONS_VERSION = "7.2.2";
+  public static final String REACTIVE_COMMONS_VERSION = "7.3.0";
   public static final String REACTIVE_COMMONS_MAPPER_VERSION = "0.1.0";
   public static final String BLOCK_HOUND_VERSION = "1.0.17.RELEASE";
-  public static final String AWS_BOM_VERSION = "2.51.3";
+  public static final String AWS_BOM_VERSION = "2.52.0";
   public static final String COMMONS_JMS_VERSION = "3.1.3";
   public static final String ARCH_UNIT_VERSION = "1.5.0";
   public static final String OKHTTP_VERSION = "5.4.0";

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2026M03D11PitestReportAggregate.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2026M03D11PitestReportAggregate.java
@@ -62,21 +62,28 @@ public class UpgradeY2026M03D11PitestReportAggregate implements UpgradeAction {
   private static final String SPRING_BOOT_PLATFORM =
       "implementation platform(\"org.springframework.boot:spring-boot-dependencies:${springBootVersion}\")";
 
+  private static final String THREADS_REGEX = "threads\\s*=\\s*.+";
+  private static final String THREADS_NEW_VALUE = "threads = Runtime.runtime.availableProcessors()";
+
   @Override
   @SneakyThrows
   public boolean up(ModuleBuilder builder) {
-    return builder.updateFile(
-        MAIN_GRADLE,
-        content -> {
-          String partial = UpdateUtils.replace(content, OLD_PITEST_AGGREGATE, NEW_PITEST_AGGREGATE);
-          return UpdateUtils.insertAfterMatch(
-              partial,
-              SPRING_BOOT_PLATFORM,
-              "pitest-history-plugin",
-              "\n        pitest 'org.pitest:pitest-history-plugin:"
-                  .concat(Constants.PITEST_HISTORY_VERSION)
-                  .concat("'"));
-        });
+    boolean appliedAggregate =
+        builder.updateFile(
+            MAIN_GRADLE,
+            content -> {
+              String partial =
+                  UpdateUtils.replace(content, OLD_PITEST_AGGREGATE, NEW_PITEST_AGGREGATE);
+              return UpdateUtils.insertAfterMatch(
+                  partial,
+                  SPRING_BOOT_PLATFORM,
+                  "pitest-history-plugin",
+                  "\n        pitest 'org.pitest:pitest-history-plugin:"
+                      .concat(Constants.PITEST_HISTORY_VERSION)
+                      .concat("'"));
+            });
+    boolean appliedThreads = builder.updateExpression(MAIN_GRADLE, THREADS_REGEX, THREADS_NEW_VALUE);
+    return UpdateUtils.oneOfAll(appliedAggregate, appliedThreads);
   }
 
   @Override

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2026M03D11PitestReportAggregate.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2026M03D11PitestReportAggregate.java
@@ -82,7 +82,8 @@ public class UpgradeY2026M03D11PitestReportAggregate implements UpgradeAction {
                       .concat(Constants.PITEST_HISTORY_VERSION)
                       .concat("'"));
             });
-    boolean appliedThreads = builder.updateExpression(MAIN_GRADLE, THREADS_REGEX, THREADS_NEW_VALUE);
+    boolean appliedThreads =
+        builder.updateExpression(MAIN_GRADLE, THREADS_REGEX, THREADS_NEW_VALUE);
     return UpdateUtils.oneOfAll(appliedAggregate, appliedThreads);
   }
 

--- a/src/main/resources/structure/root/main.gradle.mustache
+++ b/src/main/resources/structure/root/main.gradle.mustache
@@ -76,7 +76,7 @@ subprojects {
         pitestVersion = '{{PITEST_VERSION}}'
         verbose = false
         outputFormats = ['XML', 'HTML']
-        threads = 8
+        threads = Runtime.runtime.availableProcessors()
         exportLineCoverage = true
         useClasspathFile = true
         withHistory = true

--- a/src/test/resources/pitest-report-aggregate/main-after.txt
+++ b/src/test/resources/pitest-report-aggregate/main-after.txt
@@ -40,7 +40,7 @@ subprojects {
         pitestVersion = '1.22.1'
         verbose = false
         outputFormats = ['XML', 'HTML']
-        threads = 8
+        threads = Runtime.runtime.availableProcessors()
         exportLineCoverage = true
         useClasspathFile = true
         withHistory = true


### PR DESCRIPTION
## Description
Updated the Pitest configuration to replace hardcoded thread values (e.g., threads = 8) with Runtime.runtime.availableProcessors(), enabling automatic thread allocation based on the execution environment.

## Category
- [x] Feature
- [] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing).
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog.
- [x] Automated tests are written.
- [x] The documentation is up-to-date.
- [] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request adds new template files, ensure they follow the naming convention: lowercase with hyphens (e.g., `handler-registry-configuration.java.mustache`), and test files with `.test` suffix (e.g., `handler-registry-configuration.test.java.mustache`). See the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#setupfromtemplate) for details.
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing).
- [ ] If the pull request adds task parameters, ensure they follow the naming convention: multi-word parameters with hyphens (e.g., `--server-name`), single-word without hyphens (e.g., `--type`). See the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#task-parameter-naming-convention) for details.
- [ ] If the pull request adds a new dependency constant in `Constants.java`, you should include the corresponding configuration in the `sh_dependencies.json` file.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#pull-request-criteria).
