### PR TITLE
chore(upgrades): normalize leftover Jackson 2.x version after tools.jackson migration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Thu Jun 11 10:22:25 COT 2026
+#Wed Aug 12 14:59:24 COT 2026
 systemProp.version=4.5.0
 simulateRest=true
 package=co.com.bancolombia

--- a/sh_dependencies.json
+++ b/sh_dependencies.json
@@ -73,6 +73,10 @@
             "packageName": "org.springaicommunity:mcp-server-security"
         },
         {
+            "name": "JACKSON_VERSION",
+            "packageName": "tools.jackson.core:jackson-core"
+        },
+        {
             "name": "PITEST_VERSION",
             "packageName": "org.pitest:pitest"
         },

--- a/src/main/java/co/com/bancolombia/Constants.java
+++ b/src/main/java/co/com/bancolombia/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
   public static final String REACTOR_KAFKA_VERSION = "1.3.25";
   public static final String SPRING_AI_VERSION = "2.0.0";
   public static final String SPRING_MCP_SECURITY_VERSION = "0.1.14";
+  public static final String JACKSON_VERSION = "3.2.1";
   public static final String PITEST_VERSION = "1.25.9";
   public static final String PITEST_HISTORY_VERSION = "0.0.1";
   public static final String PITEST_JUNIT5_VERSION = "1.2.3";

--- a/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M12D12SpringBoot4.java
+++ b/src/main/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M12D12SpringBoot4.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.factory.upgrades.actions;
 
+import co.com.bancolombia.Constants;
 import co.com.bancolombia.factory.ModuleBuilder;
 import co.com.bancolombia.factory.upgrades.UpdateUtils;
 import co.com.bancolombia.factory.upgrades.UpgradeAction;
@@ -10,6 +11,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.gradle.api.logging.Logger;
 
 public class UpgradeY2025M12D12SpringBoot4 implements UpgradeAction {
+
+  private static final String JACKSON_TOOLS_OLD_VERSION_REGEX =
+      "(tools\\.jackson(?:\\.\\w+)?:jackson-[\\w-]+:)(?!3\\.)[^'\"\\s]+";
 
   @Override
   public boolean up(ModuleBuilder builder) {
@@ -193,6 +197,13 @@ public class UpgradeY2025M12D12SpringBoot4 implements UpgradeAction {
                         updatedContent,
                         "tools.jackson.core:jackson-annotations",
                         "com.fasterxml.jackson.core:jackson-annotations");
+                // Jackson 2.x version pins are invalid under the new tools.jackson group id
+                // (that group id only exists starting with Jackson 3.x), so any leftover
+                // 2.x version (e.g. inherited from a prior dependency update) must be
+                // normalized to a valid Jackson 3.x version.
+                updatedContent =
+                    updatedContent.replaceAll(
+                        JACKSON_TOOLS_OLD_VERSION_REGEX, "$1" + Constants.JACKSON_VERSION);
                 updatedContent =
                     UpdateUtils.replace(
                         updatedContent, "JsonProcessingException", "JacksonException");

--- a/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M12D12SpringBoot4Test.java
+++ b/src/test/java/co/com/bancolombia/factory/upgrades/actions/UpgradeY2025M12D12SpringBoot4Test.java
@@ -1,7 +1,10 @@
 package co.com.bancolombia.factory.upgrades.actions;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -12,11 +15,15 @@ import co.com.bancolombia.factory.upgrades.UpgradeAction;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.stream.Stream;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -69,5 +76,49 @@ class UpgradeY2025M12D12SpringBoot4Test {
     assertTrue(applied);
     verify(builder, times(1))
         .addFile(file, "testImplementation \"tools.jackson.core:jackson-databind\"");
+  }
+
+  @Test
+  void shouldNormalizeLeftoverJackson2VersionAfterGroupIdMigration() throws IOException {
+    builder = spy(new ModuleBuilder(project));
+    File gradleFile = new File(tempDir, "build.gradle");
+    Files.writeString(
+        gradleFile.toPath(),
+        "testImplementation \"com.fasterxml.jackson.core:jackson-databind:2.21.1\"");
+    String file = gradleFile.getAbsolutePath();
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertTrue(applied);
+    verify(builder, times(1))
+        .addFile(file, "testImplementation \"tools.jackson.core:jackson-databind:3.2.1\"");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("unchangedJacksonDependencyCases")
+  void shouldNotChangeAlreadyValidOrManagedJacksonDependencies(String description, String content)
+      throws IOException {
+    builder = spy(new ModuleBuilder(project));
+    File gradleFile = new File(tempDir, "build.gradle");
+    Files.writeString(gradleFile.toPath(), content);
+    String file = gradleFile.getAbsolutePath();
+    // Act
+    boolean applied = updater.up(builder);
+    // Assert
+    assertFalse(applied, "Expected no update to be applied for case: " + description);
+    verify(builder, times(0)).addFile(eq(file), any());
+  }
+
+  private static Stream<Arguments> unchangedJacksonDependencyCases() {
+    return Stream.of(
+        Arguments.of(
+            "already migrated Jackson 3 version",
+            "testImplementation \"tools.jackson.core:jackson-databind:3.2.1\""),
+        Arguments.of(
+            "dependency without version managed by Spring Boot BOM",
+            "implementation 'tools.jackson.core:jackson-databind'"),
+        Arguments.of(
+            "jackson-annotations group id and version",
+            "testImplementation \"com.fasterxml.jackson.core:jackson-annotations:2.21.1\""));
   }
 }


### PR DESCRIPTION
## Description
Fixes a bug in `UpgradeY2025M12D12SpringBoot4` where dependencies migrating from `com.fasterxml.jackson` to `tools.jackson` could end up with an invalid GAV coordinate.

When `UpdateDependencies` runs before this upgrade action (both are sorted alphabetically by class name), it may bump a Jackson dependency version within the 2.x line, e.g.:

      com.fasterxml.jackson.core:jackson-databind:2.22.1
      -> com.fasterxml.jackson.core:jackson-databind:2.21.1

  `UpgradeY2025M12D12SpringBoot4` then rewrites the group id to `tools.jackson`,
  leaving an invalid coordinate that doesn't exist in Maven Central, since the
  `tools.jackson` group id only ships Jackson 3.x releases:

      tools.jackson.core:jackson-databind:2.21.1   // invalid, breaks dependency resolution

  ### Changes

  - Added `Constants.JACKSON_VERSION = "3.2.1"` (registered in `sh_dependencies.json`
    for automated version tracking).
  - `UpgradeY2025M12D12SpringBoot4`: after the `com.fasterxml.jackson` ->
    `tools.jackson` group id/package migration, normalize any leftover non-3.x
    version pinned on a `tools.jackson.*` coordinate to `Constants.JACKSON_VERSION`.
    - Dependencies without an explicit version (managed by the Spring Boot BOM)
      are left untouched.
    - `jackson-annotations` is unaffected (per the Jackson 3 migration guide,
      it stays on `com.fasterxml.jackson` with its 2.x version).
  - Added/refactored unit tests in `UpgradeY2025M12D12SpringBoot4Test`:
    - New case covering the reported bug (2.x version normalized to 3.x).
    - Consolidated three near-identical "no-op" test cases (already-migrated
      3.x version, unversioned BOM-managed dependency, `jackson-annotations`)
      into a single `@ParameterizedTest` to address the Sonar warning
      "Replace these 3 tests with a single Parameterized one".

  ### Testing

  - Full unit test suite: 272 tests, 0 failures, 0 errors.
  - Verified end-to-end with the exact scenario reported: a project with
    `com.fasterxml.jackson.core:jackson-databind:2.22.1` no longer produces an
    invalid `tools.jackson.core:jackson-databind:2.x` coordinate after upgrade.

## Category
- [ ] Feature
- [x] Fix
- [ ] Ci / Docs

## Checklist
- [x] The pull request is complete according to the [guide of contributing](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing).
- [x] The pull request has a descriptive title that describes what has changed, and provides enough context for the changelog.
- [x] Automated tests are written.
- [x] The documentation is up-to-date.
- [ ] If the pull request has a new driven-adapter or entry-point, you should add it to docs and `sh_generate_project.sh` files for generated code tests.
- [ ] If the pull request adds new template files, ensure they follow the naming convention: lowercase with hyphens (e.g., `handler-registry-configuration.java.mustache`), and test files with `.test` suffix (e.g., `handler-registry-configuration.test.java.mustache`). See the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#setupfromtemplate) for details.
- [ ] If the pull request has a new Gradle Task, you should add `Analytics` according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing).
- [ ] If the pull request adds task parameters, ensure they follow the naming convention: multi-word parameters with hyphens (e.g., `--server-name`), single-word without hyphens (e.g., `--type`). See the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#task-parameter-naming-convention) for details.
- [x] If the pull request adds a new dependency constant in `Constants.java`, you should include the corresponding configuration in the `sh_dependencies.json` file.
- [ ] If the pull request has changed structural files, you have implemented an UpgradeAction according to the [guide](https://bancolombia.github.io/scaffold-clean-architecture/docs/contributing#pull-request-criteria).
